### PR TITLE
ch10: fix Unbound value Draw.grey against bogue 20260208

### DIFF
--- a/README.md
+++ b/README.md
@@ -9904,7 +9904,7 @@ let reactimate (scene : scene behavior) =
   let current = ref sc0 in
 
   Sdl_area.add area (fun _renderer ->
-    Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)
+    Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color "grey"))
       ~w ~h (0, 0);
     while !pending > 0 do
       decr pending;
@@ -10518,7 +10518,7 @@ let run_bogue ~(w : int) ~(h : int) (script : unit -> unit) : unit =
   in
 
   Sdl_area.add area (fun _renderer ->
-    Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)
+    Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color "grey"))
       ~w ~h (0, 0);
     draw area ~h !current);
 
@@ -11721,13 +11721,25 @@ Adding a new constructor — say `type _ expr += Str : string -> string expr` in
 - **Separate evaluators per sub-language are not composable without boilerplate**: the `build_eval` infrastructure is non-trivial and must be replicated for each operation.
 - **The untyped lambda calculus does not fit cleanly**: the running example from earlier sections uses an untyped `App` and `Abs` with a uniform `expr` type. Fitting lambda calculus into a typed GADT requires either a universal value type (`type value = VInt of int | VLam of (value -> value)`) or moving to a typed lambda calculus with de Bruijn indices — significantly increasing complexity.
 
+  To see why concretely, consider the most natural attempt:
+
+  ```ocaml skip
+  (* Attempt: lambda calculus as an extensible GADT *)
+  type _ expr +=
+    | Var : string -> 'a expr          (* 'a is unconstrained — what type does a variable have? *)
+    | Abs : string * 'b expr -> ('a -> 'b) expr   (* 'a is not bound to anything *)
+    | App : ('a -> 'b) expr * 'a expr -> 'b expr
+  ```
+
+  The problem is `Var`: a free variable could have any type, so `'a` is existentially unconstrained — the type checker cannot determine what `'a` is at runtime. Similarly, `Abs` introduces a parameter of type `'a`, but nothing in the constructor's payload pins `'a` to a concrete type. Without a type environment threaded through the GADT index (as in a de Bruijn-indexed typed lambda calculus), a uniform `eval : 'a expr -> 'a` function cannot be written.
+
 **Verdict:** A non-solution, but with a stronger typing guarantee than plain extensible variants (section 11.3): constructors that *are* handled are type-safe without runtime coercions. The penalty for unhandled constructors is identical. Compared to polymorphic variants (sections 11.7–11.8), extensible GADTs provide finer type indices but sacrifice exhaustiveness checking.
 
-| Approach | Data extensibility | Functional extensibility | Exhaustiveness | Type precision |
-|---|---|---|---|---|
-| Extensible variants (11.3) | ✓ | ✓ | ✗ | Low (unindexed) |
-| **Extensible GADTs (11.9)** | ✓ | ✓ | ✗ | **High (indexed)** |
-| Polymorphic variants (11.7–11.8) | ✓ | ✓ | ✓ | Medium (row types) |
+All three extensible approaches — extensible variants (section 11.3), extensible GADTs (this section), and polymorphic variants (sections 11.7–11.8) — support both data extensibility and functional extensibility. The interesting distinctions lie in a three-way tradeoff:
+
+- **Exhaustiveness checking**: Only polymorphic variants provide it. With extensible variants and extensible GADTs, new constructors are silently skipped by catch-all handlers, producing runtime failures rather than compile-time warnings.
+- **Type precision**: Extensible GADTs offer the finest type guarantees — each constructor's return type is indexed, so handled cases are type-safe without runtime coercions. Polymorphic variants give row-type precision (the type tracks which tags are present), while plain extensible variants carry no type-level distinction between constructors.
+- **Separate-compilation friendliness**: Extensible variants and GADTs extend cleanly across module boundaries with simple `type t += ...` declarations. Polymorphic variants with recursive modules require tying type-level knots across compilation units, making cross-module composition more complex.
 
 ### 11.10 Parser Combinators
 
@@ -12103,6 +12115,16 @@ What are the benefits and drawbacks of our lazy-monad-plus (built on top of *odd
 2. Select one example from Lecture 8 and rewrite it using lazy-monad-plus and odd lazy lists.
 
 (In an "odd" lazy list, the first element is strict and only the tail is lazy. In an "even" lazy list, the entire list is wrapped in laziness. The choice affects when computation happens and how infinite structures are handled.)
+
+
+#### Exercise 14: Extensible GADT Pretty-Printer
+
+Using the extensible GADT infrastructure from `chapter11/ExtGADT.ml` (section 11.9):
+
+1. The existing `eval_layer` type is `{ layer : 'a. eval_chain -> 'a expr -> 'a option }` — the return type varies with the expression's type index. A pretty-printer always returns `string`, so it cannot reuse `eval_layer` directly. Define new record types `string_chain` and `string_layer` analogous to `eval_chain` and `eval_layer`, where the handler always returns `string option` regardless of the expression's type index. Then implement `arith_string_layer` and `bool_string_layer` that convert arithmetic and boolean expressions to strings, using the `string_chain` for recursive calls.
+2. Write a `build_string_eval` function (analogous to `build_eval`) that ties the open-recursion knot for `string_layer` values, producing a `string_chain`. Compose your layers to obtain a complete `string_of_expr : 'a expr -> string`. Test it on expressions like `Add (Num 2, Num 3)` and `Gt (Num 1, Num 0)`.
+3. Now compose the pretty-printer with the arithmetic evaluator: build a program that uses both `build_eval` (with `arith_layer` and `bool_layer`) and `build_string_eval` (with your string layers) on the same expressions. Observe that the two operations require separate composition pipelines.
+4. Identify which parts of the `build_eval` boilerplate had to be duplicated for `build_string_eval` (the mutable reference, the `List.find_map` loop, the initialization). Is this duplication acceptable, or does it suggest a further abstraction? Optionally, factor the common pattern into a functor or higher-order function parameterized by the chain and layer types.
 
 
 ## Chapter 12: Categories and GADTs

--- a/chapter10/README.md
+++ b/chapter10/README.md
@@ -971,7 +971,7 @@ let reactimate (scene : scene behavior) =
   let current = ref sc0 in
 
   Sdl_area.add area (fun _renderer ->
-    Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)
+    Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color "grey"))
       ~w ~h (0, 0);
     while !pending > 0 do
       decr pending;
@@ -1585,7 +1585,7 @@ let run_bogue ~(w : int) ~(h : int) (script : unit -> unit) : unit =
   in
 
   Sdl_area.add area (fun _renderer ->
-    Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)
+    Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color "grey"))
       ~w ~h (0, 0);
     draw area ~h !current);
 

--- a/chapter10/chapter10.ml
+++ b/chapter10/chapter10.ml
@@ -411,7 +411,7 @@ module LwdPaddle = struct
     Sdl_area.add area (fun _renderer ->
       let t = Unix.gettimeofday () -. t0 in
       Lwd.set time_v t;
-      Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)
+      Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color "grey"))
         ~w ~h (0, 0);
       let sc = Lwd.quick_sample root in
       draw area ~h sc);
@@ -720,7 +720,7 @@ module StreamFRP = struct
       let r = ref sc0 in
 
       Sdl_area.add area (fun _renderer ->
-        Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)
+        Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color "grey"))
           ~w ~h (0, 0);
         while !pending > 0 do
           decr pending;
@@ -970,7 +970,7 @@ module EffectsPaddle = struct
      | Awaiting {feed} -> st_ref := feed (User (Resize (w, h))));
 
     Sdl_area.add area (fun _renderer ->
-      Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)
+      Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color "grey"))
         ~w ~h (0, 0);
       draw area ~h !current);
 

--- a/site/new_book.html
+++ b/site/new_book.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
@@ -9,7 +9,9 @@
   <meta name="author" content="GPT-5.2" />
   <title>Curious OCaml</title>
   <style>
-    code{white-space: pre-wrap;}
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
     span.smallcaps{font-variant: small-caps;}
     div.columns{display: flex; gap: min(4vw, 1.5em);}
     div.column{flex: auto; overflow-x: auto;}
@@ -1248,10 +1250,26 @@ Polymorphic Variants</a></li>
 <li><a href="#polymorphic-variants-with-recursive-modules"
 id="toc-polymorphic-variants-with-recursive-modules">11.8 Polymorphic
 Variants with Recursive Modules</a></li>
-<li><a href="#parser-combinators" id="toc-parser-combinators">11.9
+<li><a href="#extensible-gadts-strong-typing-same-non-solution"
+id="toc-extensible-gadts-strong-typing-same-non-solution">11.9
+Extensible GADTs: Strong Typing, Same Non-Solution</a>
+<ul>
+<li><a href="#syntax-and-type-precision"
+id="toc-syntax-and-type-precision">Syntax and Type Precision</a></li>
+<li><a href="#typed-evaluation-with-required-catch-all"
+id="toc-typed-evaluation-with-required-catch-all">Typed Evaluation with
+Required Catch-All</a></li>
+<li><a href="#handler-composition-with-open-recursion"
+id="toc-handler-composition-with-open-recursion">Handler Composition
+with Open Recursion</a></li>
+<li><a href="#why-this-is-still-a-non-solution"
+id="toc-why-this-is-still-a-non-solution">Why This Is Still a
+Non-Solution</a></li>
+</ul></li>
+<li><a href="#parser-combinators" id="toc-parser-combinators">11.10
 Parser Combinators</a></li>
 <li><a href="#parser-combinators-implementation"
-id="toc-parser-combinators-implementation">11.10 Parser Combinators:
+id="toc-parser-combinators-implementation">11.11 Parser Combinators:
 Implementation</a>
 <ul>
 <li><a href="#implementation-of-lazy-monad-plus"
@@ -1264,20 +1282,20 @@ id="toc-additional-parser-operations">Additional Parser
 Operations</a></li>
 </ul></li>
 <li><a href="#parser-combinators-tying-the-recursive-knot"
-id="toc-parser-combinators-tying-the-recursive-knot">11.11 Parser
+id="toc-parser-combinators-tying-the-recursive-knot">11.12 Parser
 Combinators: Tying the Recursive Knot</a></li>
 <li><a href="#parser-combinators-dynamic-code-loading"
-id="toc-parser-combinators-dynamic-code-loading">11.12 Parser
+id="toc-parser-combinators-dynamic-code-loading">11.13 Parser
 Combinators: Dynamic Code Loading</a></li>
 <li><a href="#parser-combinators-toy-example"
-id="toc-parser-combinators-toy-example">11.13 Parser Combinators: Toy
+id="toc-parser-combinators-toy-example">11.14 Parser Combinators: Toy
 Example</a>
 <ul>
 <li><a href="#chapter-summary-what-to-remember"
 id="toc-chapter-summary-what-to-remember">Chapter Summary (What to
 Remember)</a></li>
 </ul></li>
-<li><a href="#exercises-10" id="toc-exercises-10">11.14 Exercises</a>
+<li><a href="#exercises-10" id="toc-exercises-10">11.15 Exercises</a>
 <ul>
 <li><a href="#exercise-1-pretty-printers-for-evaluators"
 id="toc-exercise-1-pretty-printers-for-evaluators">Exercise 1:
@@ -1318,6 +1336,9 @@ Combinator _of_string</a></li>
 <li><a href="#exercise-13-odd-vs-even-lazy-monad-plus"
 id="toc-exercise-13-odd-vs-even-lazy-monad-plus">Exercise 13: Odd vs
 Even Lazy Monad-Plus</a></li>
+<li><a href="#exercise-14-extensible-gadt-pretty-printer"
+id="toc-exercise-14-extensible-gadt-pretty-printer">Exercise 14:
+Extensible GADT Pretty-Printer</a></li>
 </ul></li>
 </ul></li>
 <li><a href="#chapter-12-categories-and-gadts"
@@ -13401,7 +13422,7 @@ class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb407-1"><a hr
 <span id="cb407-51"><a href="#cb407-51" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> current = <span class="dt">ref</span> sc0 <span class="kw">in</span></span>
 <span id="cb407-52"><a href="#cb407-52" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb407-53"><a href="#cb407-53" aria-hidden="true" tabindex="-1"></a>  Sdl_area.add area (<span class="kw">fun</span> _renderer -&gt;</span>
-<span id="cb407-54"><a href="#cb407-54" aria-hidden="true" tabindex="-1"></a>    Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)</span>
+<span id="cb407-54"><a href="#cb407-54" aria-hidden="true" tabindex="-1"></a>    Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color <span class="st">&quot;grey&quot;</span>))</span>
 <span id="cb407-55"><a href="#cb407-55" aria-hidden="true" tabindex="-1"></a>      ~w ~h (<span class="dv">0</span>, <span class="dv">0</span>);</span>
 <span id="cb407-56"><a href="#cb407-56" aria-hidden="true" tabindex="-1"></a>    <span class="kw">while</span> !pending &gt; <span class="dv">0</span> <span class="kw">do</span></span>
 <span id="cb407-57"><a href="#cb407-57" aria-hidden="true" tabindex="-1"></a>      <span class="dt">decr</span> pending;</span>
@@ -14051,7 +14072,7 @@ class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb422-1"><a hr
 <span id="cb422-23"><a href="#cb422-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">in</span></span>
 <span id="cb422-24"><a href="#cb422-24" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb422-25"><a href="#cb422-25" aria-hidden="true" tabindex="-1"></a>  Sdl_area.add area (<span class="kw">fun</span> _renderer -&gt;</span>
-<span id="cb422-26"><a href="#cb422-26" aria-hidden="true" tabindex="-1"></a>    Sdl_area.fill_rectangle area ~color:(Draw.opaque Draw.grey)</span>
+<span id="cb422-26"><a href="#cb422-26" aria-hidden="true" tabindex="-1"></a>    Sdl_area.fill_rectangle area ~color:(Draw.opaque (Draw.find_color <span class="st">&quot;grey&quot;</span>))</span>
 <span id="cb422-27"><a href="#cb422-27" aria-hidden="true" tabindex="-1"></a>      ~w ~h (<span class="dv">0</span>, <span class="dv">0</span>);</span>
 <span id="cb422-28"><a href="#cb422-28" aria-hidden="true" tabindex="-1"></a>    draw area ~h !current);</span>
 <span id="cb422-29"><a href="#cb422-29" aria-hidden="true" tabindex="-1"></a></span>
@@ -14250,10 +14271,12 @@ alt="Chapter 11 illustration" />
 <ul>
 <li>Understand the expression problem and why it matters for evolving
 codebases</li>
-<li>Compare extensibility trade-offs across ADTs, objects, and variants
-in OCaml</li>
+<li>Compare extensibility trade-offs across ADTs, objects, variants, and
+GADTs in OCaml</li>
 <li>Learn how polymorphic variants and recursive modules enable modular
 extension</li>
+<li>Understand why extensible GADTs offer stronger typing but the same
+exhaustiveness penalty</li>
 <li>Build a practical capstone: parser combinators (including dynamic
 loading)</li>
 </ul>
@@ -15256,7 +15279,208 @@ class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb446-1"><a hr
 <span id="cb446-25"><a href="#cb446-25" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> fv_test3 = LExpr.freevars test3</span>
 <span id="cb446-26"><a href="#cb446-26" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> e_old_test = LExpr.eval [] (test2 :&gt; LExpr.<span class="dt">exp</span>)</span>
 <span id="cb446-27"><a href="#cb446-27" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> fv_old_test = LExpr.freevars (test2 :&gt; LExpr.<span class="dt">exp</span>)</span></code></pre></div>
-<h2 id="parser-combinators">11.9 Parser Combinators</h2>
+<h2 id="extensible-gadts-strong-typing-same-non-solution">11.9
+Extensible GADTs: Strong Typing, Same Non-Solution</h2>
+<p>OCaml’s <strong>extensible variant types</strong>
+(<code>type expr = ..</code>, section 11.3) allow open data definitions
+but give up exhaustiveness checking. <strong>GADTs</strong> (Generalized
+Algebraic Data Types, covered in Chapter 9) add type-level precision:
+each constructor specifies the exact type it produces. Can combining
+these two features — extensible <em>and</em> typed — solve the
+expression problem?</p>
+<p>The answer is <em>almost, but not quite</em>. Extensible GADTs give
+stronger compile-time guarantees per constructor, but OCaml still cannot
+check exhaustiveness for an open type, so every pattern match still
+requires a catch-all arm.</p>
+<h3 id="syntax-and-type-precision">Syntax and Type Precision</h3>
+<p>We declare an extensible GADT with <code>type _ expr = ..</code> —
+the <code>_</code> is the type parameter that each constructor fills
+in:</p>
+<div class="sourceCode" id="cb447"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb447-1"><a href="#cb447-1" aria-hidden="true" tabindex="-1"></a><span class="co">(** Extensible GADT: </span><span class="ot">[</span>&#39;a expr<span class="ot">]</span><span class="co"> is an expression that evaluates to a value of type </span><span class="ot">[</span>&#39;a<span class="ot">]</span><span class="co">. *)</span></span>
+<span id="cb447-2"><a href="#cb447-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> _ expr = ..</span>
+<span id="cb447-3"><a href="#cb447-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb447-4"><a href="#cb447-4" aria-hidden="true" tabindex="-1"></a><span class="co">(** Arithmetic sub-language: all constructors produce </span><span class="ot">[</span><span class="dt">int</span><span class="ot">]</span><span class="co">. *)</span></span>
+<span id="cb447-5"><a href="#cb447-5" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> _ expr +=</span>
+<span id="cb447-6"><a href="#cb447-6" aria-hidden="true" tabindex="-1"></a>  | Num : <span class="dt">int</span> -&gt; <span class="dt">int</span> expr</span>
+<span id="cb447-7"><a href="#cb447-7" aria-hidden="true" tabindex="-1"></a>  | Add : <span class="dt">int</span> expr * <span class="dt">int</span> expr -&gt; <span class="dt">int</span> expr</span>
+<span id="cb447-8"><a href="#cb447-8" aria-hidden="true" tabindex="-1"></a>  | Mul : <span class="dt">int</span> expr * <span class="dt">int</span> expr -&gt; <span class="dt">int</span> expr</span></code></pre></div>
+<p>With plain extensible variants (<code>type expr = ..</code>) all
+constructors share the same unindexed type <code>expr</code>. Here,
+<code>Num 3 : int expr</code>, <code>Add (…) : int expr</code>, so the
+compiler can statically distinguish integer expressions from expressions
+of other types.</p>
+<p>We extend later with a boolean sub-language, including a
+<strong>cross-type</strong> constructor <code>Gt</code> whose
+sub-expressions are <code>int expr</code> but whose result is
+<code>bool expr</code>:</p>
+<div class="sourceCode" id="cb448"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb448-1"><a href="#cb448-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> _ expr +=</span>
+<span id="cb448-2"><a href="#cb448-2" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Bool</span> : <span class="dt">bool</span> -&gt; <span class="dt">bool</span> expr</span>
+<span id="cb448-3"><a href="#cb448-3" aria-hidden="true" tabindex="-1"></a>  | And  : <span class="dt">bool</span> expr * <span class="dt">bool</span> expr -&gt; <span class="dt">bool</span> expr</span>
+<span id="cb448-4"><a href="#cb448-4" aria-hidden="true" tabindex="-1"></a>  | Not  : <span class="dt">bool</span> expr -&gt; <span class="dt">bool</span> expr</span>
+<span id="cb448-5"><a href="#cb448-5" aria-hidden="true" tabindex="-1"></a>  | Gt   : <span class="dt">int</span> expr * <span class="dt">int</span> expr -&gt; <span class="dt">bool</span> expr</span></code></pre></div>
+<h3 id="typed-evaluation-with-required-catch-all">Typed Evaluation with
+Required Catch-All</h3>
+<p>Matching a GADT requires a locally abstract type
+(<code>type a.</code>). The type checker refines <code>a</code> in each
+arm — matching <code>Num n</code> proves <code>a = int</code>, so
+<code>n : int</code> and the return type <code>a</code> is resolved to
+<code>int</code>:</p>
+<div class="sourceCode" id="cb449"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb449-1"><a href="#cb449-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> eval_arith : <span class="kw">type</span> a. a expr -&gt; a = <span class="kw">function</span></span>
+<span id="cb449-2"><a href="#cb449-2" aria-hidden="true" tabindex="-1"></a>  | Num n        -&gt; n</span>
+<span id="cb449-3"><a href="#cb449-3" aria-hidden="true" tabindex="-1"></a>  | Add (e1, e2) -&gt; eval_arith e1 + eval_arith e2</span>
+<span id="cb449-4"><a href="#cb449-4" aria-hidden="true" tabindex="-1"></a>  | Mul (e1, e2) -&gt; eval_arith e1 * eval_arith e2</span>
+<span id="cb449-5"><a href="#cb449-5" aria-hidden="true" tabindex="-1"></a>  | _            -&gt; <span class="dt">failwith</span> <span class="st">&quot;eval_arith: unhandled constructor&quot;</span></span>
+<span id="cb449-6"><a href="#cb449-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* ^^^ Required because [_ expr] is extensible:</span></span>
+<span id="cb449-7"><a href="#cb449-7" aria-hidden="true" tabindex="-1"></a><span class="co">     the compiler cannot verify all constructors are covered. *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb450"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb450-1"><a href="#cb450-1" aria-hidden="true" tabindex="-1"></a># eval_arith (Add (Mul (Num <span class="dv">3</span>, Num <span class="dv">4</span>), Num <span class="dv">2</span>));;</span>
+<span id="cb450-2"><a href="#cb450-2" aria-hidden="true" tabindex="-1"></a>- : <span class="dt">int</span> = <span class="dv">14</span></span></code></pre></div>
+<p>The <code>Gt</code> constructor in the boolean evaluator benefits
+directly from type precision: <code>e1 : int expr</code>, so
+<code>eval_arith e1 : int</code> without any wrapping or unboxing. With
+plain extensible variants, <code>eval_rec e1 : expr</code> and we would
+need an additional pattern match to extract the integer value:</p>
+<div class="sourceCode" id="cb451"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb451-1"><a href="#cb451-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> eval_bool : <span class="kw">type</span> a. a expr -&gt; a = <span class="kw">function</span></span>
+<span id="cb451-2"><a href="#cb451-2" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Bool</span> b       -&gt; b</span>
+<span id="cb451-3"><a href="#cb451-3" aria-hidden="true" tabindex="-1"></a>  | And (e1, e2) -&gt; eval_bool e1 &amp;&amp; eval_bool e2</span>
+<span id="cb451-4"><a href="#cb451-4" aria-hidden="true" tabindex="-1"></a>  | Not e        -&gt; <span class="dt">not</span> (eval_bool e)</span>
+<span id="cb451-5"><a href="#cb451-5" aria-hidden="true" tabindex="-1"></a>  | Gt (e1, e2)  -&gt; eval_arith e1 &gt; eval_arith e2</span>
+<span id="cb451-6"><a href="#cb451-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* ^^^ eval_arith e1 : int, e2 : int  — types known at compile time *)</span></span>
+<span id="cb451-7"><a href="#cb451-7" aria-hidden="true" tabindex="-1"></a>  | _            -&gt; <span class="dt">failwith</span> <span class="st">&quot;eval_bool: unhandled constructor&quot;</span></span></code></pre></div>
+<div class="sourceCode" id="cb452"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb452-1"><a href="#cb452-1" aria-hidden="true" tabindex="-1"></a># eval_bool (Gt (Add (Num <span class="dv">2</span>, Num <span class="dv">3</span>), Num <span class="dv">4</span>));;</span>
+<span id="cb452-2"><a href="#cb452-2" aria-hidden="true" tabindex="-1"></a>- : <span class="dt">bool</span> = <span class="kw">true</span></span></code></pre></div>
+<h3 id="handler-composition-with-open-recursion">Handler Composition
+with Open Recursion</h3>
+<p>Separate evaluators per sub-language only work when constructors stay
+within their own sub-language. The moment we want a <em>composed</em>
+evaluator for an extended language, we face the same tying-the-knot
+problem as section 11.3. The pattern from the <a
+href="https://discuss.ocaml.org/t/best-approach-for-implementing-open-recursion-over-extensible-types/11678">OCaml
+Discuss thread</a> composes partial <em>layers</em>, each of which
+handles its own constructors and delegates unknown ones:</p>
+<div class="sourceCode" id="cb453"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb453-1"><a href="#cb453-1" aria-hidden="true" tabindex="-1"></a><span class="co">(** A composed evaluator uses a universally polymorphic </span><span class="ot">[</span>eval<span class="ot">]</span><span class="co"> field so a</span></span>
+<span id="cb453-2"><a href="#cb453-2" aria-hidden="true" tabindex="-1"></a><span class="co">    single value handles expressions of any type index. *)</span></span>
+<span id="cb453-3"><a href="#cb453-3" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> eval_chain = { eval : &#39;a. &#39;a expr -&gt; &#39;a }</span>
+<span id="cb453-4"><a href="#cb453-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb453-5"><a href="#cb453-5" aria-hidden="true" tabindex="-1"></a><span class="co">(** Each layer handles some constructors (</span><span class="ot">[</span><span class="dt">Some</span> <span class="dt">result</span><span class="ot">]</span><span class="co">) or delegates (</span><span class="ot">[</span><span class="dt">None</span><span class="ot">]</span><span class="co">). *)</span></span>
+<span id="cb453-6"><a href="#cb453-6" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> eval_layer = { layer : &#39;a. eval_chain -&gt; &#39;a expr -&gt; &#39;a <span class="dt">option</span> }</span></code></pre></div>
+<div class="sourceCode" id="cb454"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb454-1"><a href="#cb454-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> arith_layer = {</span>
+<span id="cb454-2"><a href="#cb454-2" aria-hidden="true" tabindex="-1"></a>  layer = <span class="kw">fun</span> (<span class="kw">type</span> a) (chain : eval_chain) (e : a expr) : a <span class="dt">option</span> -&gt;</span>
+<span id="cb454-3"><a href="#cb454-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">match</span> e <span class="kw">with</span></span>
+<span id="cb454-4"><a href="#cb454-4" aria-hidden="true" tabindex="-1"></a>    | Num n        -&gt; <span class="dt">Some</span> n</span>
+<span id="cb454-5"><a href="#cb454-5" aria-hidden="true" tabindex="-1"></a>    | Add (e1, e2) -&gt; <span class="dt">Some</span> (chain.eval e1 + chain.eval e2)</span>
+<span id="cb454-6"><a href="#cb454-6" aria-hidden="true" tabindex="-1"></a>    | Mul (e1, e2) -&gt; <span class="dt">Some</span> (chain.eval e1 * chain.eval e2)</span>
+<span id="cb454-7"><a href="#cb454-7" aria-hidden="true" tabindex="-1"></a>    | _            -&gt; <span class="dt">None</span> }</span>
+<span id="cb454-8"><a href="#cb454-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb454-9"><a href="#cb454-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> bool_layer = {</span>
+<span id="cb454-10"><a href="#cb454-10" aria-hidden="true" tabindex="-1"></a>  layer = <span class="kw">fun</span> (<span class="kw">type</span> a) (chain : eval_chain) (e : a expr) : a <span class="dt">option</span> -&gt;</span>
+<span id="cb454-11"><a href="#cb454-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">match</span> e <span class="kw">with</span></span>
+<span id="cb454-12"><a href="#cb454-12" aria-hidden="true" tabindex="-1"></a>    | <span class="dt">Bool</span> b       -&gt; <span class="dt">Some</span> b</span>
+<span id="cb454-13"><a href="#cb454-13" aria-hidden="true" tabindex="-1"></a>    | And (e1, e2) -&gt; <span class="dt">Some</span> (chain.eval e1 &amp;&amp; chain.eval e2)</span>
+<span id="cb454-14"><a href="#cb454-14" aria-hidden="true" tabindex="-1"></a>    | Not e        -&gt; <span class="dt">Some</span> (<span class="dt">not</span> (chain.eval e))</span>
+<span id="cb454-15"><a href="#cb454-15" aria-hidden="true" tabindex="-1"></a>    | Gt (e1, e2)  -&gt; <span class="dt">Some</span> (chain.eval e1 &gt; chain.eval e2)</span>
+<span id="cb454-16"><a href="#cb454-16" aria-hidden="true" tabindex="-1"></a>    <span class="co">(* ^^^ chain.eval : &#39;b. &#39;b expr -&gt; &#39;b, so chain.eval e1 : int directly *)</span></span>
+<span id="cb454-17"><a href="#cb454-17" aria-hidden="true" tabindex="-1"></a>    | _            -&gt; <span class="dt">None</span> }</span></code></pre></div>
+<p><code>build_eval</code> threads open recursion through a mutable
+reference: <code>chain</code> is set to the fully-composed evaluator
+after it is built, so every sub-expression call goes through all
+registered layers:</p>
+<div class="sourceCode" id="cb455"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb455-1"><a href="#cb455-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> build_eval (layers : eval_layer <span class="dt">list</span>) : eval_chain =</span>
+<span id="cb455-2"><a href="#cb455-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> chain : eval_chain <span class="dt">ref</span> =</span>
+<span id="cb455-3"><a href="#cb455-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ref</span> { eval = <span class="kw">fun</span> _ -&gt; <span class="dt">failwith</span> <span class="st">&quot;build_eval: not yet initialised&quot;</span> } <span class="kw">in</span></span>
+<span id="cb455-4"><a href="#cb455-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> full_eval : <span class="kw">type</span> a. a expr -&gt; a = <span class="kw">fun</span> e -&gt;</span>
+<span id="cb455-5"><a href="#cb455-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">match</span> <span class="dt">List</span>.find_map (<span class="kw">fun</span> l -&gt; l.layer !chain e) layers <span class="kw">with</span></span>
+<span id="cb455-6"><a href="#cb455-6" aria-hidden="true" tabindex="-1"></a>    | <span class="dt">Some</span> v -&gt; v</span>
+<span id="cb455-7"><a href="#cb455-7" aria-hidden="true" tabindex="-1"></a>    | <span class="dt">None</span>   -&gt; <span class="dt">failwith</span> <span class="st">&quot;build_eval: no handler for this constructor&quot;</span></span>
+<span id="cb455-8"><a href="#cb455-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">in</span></span>
+<span id="cb455-9"><a href="#cb455-9" aria-hidden="true" tabindex="-1"></a>  chain := { eval = full_eval };</span>
+<span id="cb455-10"><a href="#cb455-10" aria-hidden="true" tabindex="-1"></a>  { eval = full_eval }</span></code></pre></div>
+<div class="sourceCode" id="cb456"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb456-1"><a href="#cb456-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> combined = build_eval [arith_layer; bool_layer]</span></code></pre></div>
+<div class="sourceCode" id="cb457"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb457-1"><a href="#cb457-1" aria-hidden="true" tabindex="-1"></a># combined.eval (Gt (Add (Num <span class="dv">2</span>, Num <span class="dv">3</span>), Num <span class="dv">4</span>));;</span>
+<span id="cb457-2"><a href="#cb457-2" aria-hidden="true" tabindex="-1"></a>- : <span class="dt">bool</span> = <span class="kw">true</span></span>
+<span id="cb457-3"><a href="#cb457-3" aria-hidden="true" tabindex="-1"></a># combined.eval (Mul (Add (Num <span class="dv">3</span>, Num <span class="dv">4</span>), Num <span class="dv">2</span>));;</span>
+<span id="cb457-4"><a href="#cb457-4" aria-hidden="true" tabindex="-1"></a>- : <span class="dt">int</span> = <span class="dv">14</span></span></code></pre></div>
+<p>The full implementation is in <code>chapter11/ExtGADT.ml</code>.</p>
+<h3 id="why-this-is-still-a-non-solution">Why This Is Still a
+Non-Solution</h3>
+<p>Adding a new constructor — say
+<code>type _ expr += Str : string -&gt; string expr</code> in a new
+module — does not trigger any warning in <code>arith_layer</code> or
+<code>bool_layer</code>. The catch-all <code>| _ -&gt; None</code>
+silently skips it. Calling <code>combined.eval (Str "hello")</code>
+raises a runtime exception.</p>
+<p><strong>Non-solution penalty points:</strong></p>
+<ul>
+<li><p><strong>No exhaustiveness checking</strong>: the same core
+penalty as section 11.3 (extensible variant types). New constructors
+produce silent runtime failures, not compile-time warnings.</p></li>
+<li><p><strong>Separate evaluators per sub-language are not composable
+without boilerplate</strong>: the <code>build_eval</code> infrastructure
+is non-trivial and must be replicated for each operation.</p></li>
+<li><p><strong>The untyped lambda calculus does not fit
+cleanly</strong>: the running example from earlier sections uses an
+untyped <code>App</code> and <code>Abs</code> with a uniform
+<code>expr</code> type. Fitting lambda calculus into a typed GADT
+requires either a universal value type
+(<code>type value = VInt of int | VLam of (value -&gt; value)</code>) or
+moving to a typed lambda calculus with de Bruijn indices — significantly
+increasing complexity.</p>
+<p>To see why concretely, consider the most natural attempt:</p>
+<div class="sourceCode" id="cb458"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb458-1"><a href="#cb458-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Attempt: lambda calculus as an extensible GADT *)</span></span>
+<span id="cb458-2"><a href="#cb458-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> _ expr +=</span>
+<span id="cb458-3"><a href="#cb458-3" aria-hidden="true" tabindex="-1"></a>  | Var : <span class="dt">string</span> -&gt; &#39;a expr          <span class="co">(* &#39;a is unconstrained — what type does a variable have? *)</span></span>
+<span id="cb458-4"><a href="#cb458-4" aria-hidden="true" tabindex="-1"></a>  | Abs : <span class="dt">string</span> * &#39;b expr -&gt; (&#39;a -&gt; &#39;b) expr   <span class="co">(* &#39;a is not bound to anything *)</span></span>
+<span id="cb458-5"><a href="#cb458-5" aria-hidden="true" tabindex="-1"></a>  | App : (&#39;a -&gt; &#39;b) expr * &#39;a expr -&gt; &#39;b expr</span></code></pre></div>
+<p>The problem is <code>Var</code>: a free variable could have any type,
+so <code>'a</code> is existentially unconstrained — the type checker
+cannot determine what <code>'a</code> is at runtime. Similarly,
+<code>Abs</code> introduces a parameter of type <code>'a</code>, but
+nothing in the constructor’s payload pins <code>'a</code> to a concrete
+type. Without a type environment threaded through the GADT index (as in
+a de Bruijn-indexed typed lambda calculus), a uniform
+<code>eval : 'a expr -&gt; 'a</code> function cannot be
+written.</p></li>
+</ul>
+<p><strong>Verdict:</strong> A non-solution, but with a stronger typing
+guarantee than plain extensible variants (section 11.3): constructors
+that <em>are</em> handled are type-safe without runtime coercions. The
+penalty for unhandled constructors is identical. Compared to polymorphic
+variants (sections 11.7–11.8), extensible GADTs provide finer type
+indices but sacrifice exhaustiveness checking.</p>
+<p>All three extensible approaches — extensible variants (section 11.3),
+extensible GADTs (this section), and polymorphic variants (sections
+11.7–11.8) — support both data extensibility and functional
+extensibility. The interesting distinctions lie in a three-way
+tradeoff:</p>
+<ul>
+<li><strong>Exhaustiveness checking</strong>: Only polymorphic variants
+provide it. With extensible variants and extensible GADTs, new
+constructors are silently skipped by catch-all handlers, producing
+runtime failures rather than compile-time warnings.</li>
+<li><strong>Type precision</strong>: Extensible GADTs offer the finest
+type guarantees — each constructor’s return type is indexed, so handled
+cases are type-safe without runtime coercions. Polymorphic variants give
+row-type precision (the type tracks which tags are present), while plain
+extensible variants carry no type-level distinction between
+constructors.</li>
+<li><strong>Separate-compilation friendliness</strong>: Extensible
+variants and GADTs extend cleanly across module boundaries with simple
+<code>type t += ...</code> declarations. Polymorphic variants with
+recursive modules require tying type-level knots across compilation
+units, making cross-module composition more complex.</li>
+</ul>
+<h2 id="parser-combinators">11.10 Parser Combinators</h2>
 <p>We now turn to an application that demonstrates the extensibility
 concepts we have been discussing. Large-scale parsing in OCaml is
 typically done using external languages like OCamlLex and Menhir, which
@@ -15343,7 +15567,7 @@ requires matching <span class="math inline">N</span> again, leading to
 infinite recursion.</p>
 <p>On the other hand, rules can share common prefixes, and the
 backtracking monad will handle trying alternatives correctly.</p>
-<h2 id="parser-combinators-implementation">11.10 Parser Combinators:
+<h2 id="parser-combinators-implementation">11.11 Parser Combinators:
 Implementation</h2>
 <p>The parser monad is actually a composition of two monads:</p>
 <ul>
@@ -15368,146 +15592,146 @@ recursion in some parsing scenarios.</p>
 lazy-monad-plus</h3>
 <p>First a brief reminder about monads with backtracking. Starting with
 an operation from <code>MonadPlusOps</code>:</p>
-<div class="sourceCode" id="cb448"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb448-1"><a href="#cb448-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> msum_map f l =</span>
-<span id="cb448-2"><a href="#cb448-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.fold_left  <span class="co">(* Folding left reverses the apparent order of composition *)</span></span>
-<span id="cb448-3"><a href="#cb448-3" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">fun</span> acc a -&gt; mplus acc (<span class="kw">lazy</span> (f a))) mzero l  <span class="co">(* order from l is preserved *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb460"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb460-1"><a href="#cb460-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> msum_map f l =</span>
+<span id="cb460-2"><a href="#cb460-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.fold_left  <span class="co">(* Folding left reverses the apparent order of composition *)</span></span>
+<span id="cb460-3"><a href="#cb460-3" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">fun</span> acc a -&gt; mplus acc (<span class="kw">lazy</span> (f a))) mzero l  <span class="co">(* order from l is preserved *)</span></span></code></pre></div>
 <p>The implementation of the lazy-monad-plus using lazy lists:</p>
-<div class="sourceCode" id="cb449"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb449-1"><a href="#cb449-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a llist = LNil | LCons <span class="kw">of</span> &#39;a * &#39;a llist <span class="dt">Lazy</span>.t</span>
-<span id="cb449-2"><a href="#cb449-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb449-3"><a href="#cb449-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> ltake n = <span class="kw">function</span></span>
-<span id="cb449-4"><a href="#cb449-4" aria-hidden="true" tabindex="-1"></a>  | LCons (a, l) <span class="kw">when</span> n &gt; <span class="dv">1</span> -&gt; a::(ltake (n<span class="dv">-1</span>) (<span class="dt">Lazy</span>.force l))</span>
-<span id="cb449-5"><a href="#cb449-5" aria-hidden="true" tabindex="-1"></a>  | LCons (a, l) <span class="kw">when</span> n = <span class="dv">1</span> -&gt; [a]  <span class="co">(* Avoid forcing the tail if not needed *)</span></span>
-<span id="cb449-6"><a href="#cb449-6" aria-hidden="true" tabindex="-1"></a>  | _ -&gt; []</span>
-<span id="cb449-7"><a href="#cb449-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb449-8"><a href="#cb449-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> lappend l1 l2 =</span>
-<span id="cb449-9"><a href="#cb449-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">match</span> l1 <span class="kw">with</span> LNil -&gt; <span class="dt">Lazy</span>.force l2</span>
-<span id="cb449-10"><a href="#cb449-10" aria-hidden="true" tabindex="-1"></a>  | LCons (hd, tl) -&gt; LCons (hd, <span class="kw">lazy</span> (lappend (<span class="dt">Lazy</span>.force tl) l2))</span>
-<span id="cb449-11"><a href="#cb449-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb449-12"><a href="#cb449-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> lconcat_map f = <span class="kw">function</span></span>
-<span id="cb449-13"><a href="#cb449-13" aria-hidden="true" tabindex="-1"></a>  | LNil -&gt; LNil</span>
-<span id="cb449-14"><a href="#cb449-14" aria-hidden="true" tabindex="-1"></a>  | LCons (a, l) -&gt; lappend (f a) (<span class="kw">lazy</span> (lconcat_map f (<span class="dt">Lazy</span>.force l)))</span>
-<span id="cb449-15"><a href="#cb449-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb449-16"><a href="#cb449-16" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> LListM = MonadPlus (<span class="kw">struct</span></span>
-<span id="cb449-17"><a href="#cb449-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a llist</span>
-<span id="cb449-18"><a href="#cb449-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> bind a b = lconcat_map b a</span>
-<span id="cb449-19"><a href="#cb449-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> return a = LCons (a, <span class="kw">lazy</span> LNil)</span>
-<span id="cb449-20"><a href="#cb449-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> mzero = LNil</span>
-<span id="cb449-21"><a href="#cb449-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> mplus = lappend</span>
-<span id="cb449-22"><a href="#cb449-22" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb461"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb461-1"><a href="#cb461-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a llist = LNil | LCons <span class="kw">of</span> &#39;a * &#39;a llist <span class="dt">Lazy</span>.t</span>
+<span id="cb461-2"><a href="#cb461-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb461-3"><a href="#cb461-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> ltake n = <span class="kw">function</span></span>
+<span id="cb461-4"><a href="#cb461-4" aria-hidden="true" tabindex="-1"></a>  | LCons (a, l) <span class="kw">when</span> n &gt; <span class="dv">1</span> -&gt; a::(ltake (n<span class="dv">-1</span>) (<span class="dt">Lazy</span>.force l))</span>
+<span id="cb461-5"><a href="#cb461-5" aria-hidden="true" tabindex="-1"></a>  | LCons (a, l) <span class="kw">when</span> n = <span class="dv">1</span> -&gt; [a]  <span class="co">(* Avoid forcing the tail if not needed *)</span></span>
+<span id="cb461-6"><a href="#cb461-6" aria-hidden="true" tabindex="-1"></a>  | _ -&gt; []</span>
+<span id="cb461-7"><a href="#cb461-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb461-8"><a href="#cb461-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> lappend l1 l2 =</span>
+<span id="cb461-9"><a href="#cb461-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">match</span> l1 <span class="kw">with</span> LNil -&gt; <span class="dt">Lazy</span>.force l2</span>
+<span id="cb461-10"><a href="#cb461-10" aria-hidden="true" tabindex="-1"></a>  | LCons (hd, tl) -&gt; LCons (hd, <span class="kw">lazy</span> (lappend (<span class="dt">Lazy</span>.force tl) l2))</span>
+<span id="cb461-11"><a href="#cb461-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb461-12"><a href="#cb461-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> lconcat_map f = <span class="kw">function</span></span>
+<span id="cb461-13"><a href="#cb461-13" aria-hidden="true" tabindex="-1"></a>  | LNil -&gt; LNil</span>
+<span id="cb461-14"><a href="#cb461-14" aria-hidden="true" tabindex="-1"></a>  | LCons (a, l) -&gt; lappend (f a) (<span class="kw">lazy</span> (lconcat_map f (<span class="dt">Lazy</span>.force l)))</span>
+<span id="cb461-15"><a href="#cb461-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb461-16"><a href="#cb461-16" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> LListM = MonadPlus (<span class="kw">struct</span></span>
+<span id="cb461-17"><a href="#cb461-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a llist</span>
+<span id="cb461-18"><a href="#cb461-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> bind a b = lconcat_map b a</span>
+<span id="cb461-19"><a href="#cb461-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> return a = LCons (a, <span class="kw">lazy</span> LNil)</span>
+<span id="cb461-20"><a href="#cb461-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> mzero = LNil</span>
+<span id="cb461-21"><a href="#cb461-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> mplus = lappend</span>
+<span id="cb461-22"><a href="#cb461-22" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span>)</span></code></pre></div>
 <h3 id="the-parsec-monad">The Parsec Monad</h3>
 <p>File <code>Parsec.ml</code>:</p>
-<div class="sourceCode" id="cb450"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb450-1"><a href="#cb450-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> PARSE = <span class="kw">sig</span></span>
-<span id="cb450-2"><a href="#cb450-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a backtracking_monad  <span class="co">(* Name for the underlying monad-plus *)</span></span>
-<span id="cb450-3"><a href="#cb450-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a parsing_state = <span class="dt">int</span> -&gt; (&#39;a * <span class="dt">int</span>) backtracking_monad  <span class="co">(* State: position *)</span></span>
-<span id="cb450-4"><a href="#cb450-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = <span class="dt">string</span> -&gt; &#39;a parsing_state  <span class="co">(* Reader for the parsed text *)</span></span>
-<span id="cb450-5"><a href="#cb450-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> MONAD_PLUS_OPS</span>
-<span id="cb450-6"><a href="#cb450-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (&lt;|&gt;) : &#39;a monad -&gt; &#39;a monad <span class="dt">Lazy</span>.t -&gt; &#39;a monad  <span class="co">(* A synonym for mplus *)</span></span>
-<span id="cb450-7"><a href="#cb450-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> run : &#39;a monad -&gt; &#39;a t</span>
-<span id="cb450-8"><a href="#cb450-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> runT : &#39;a monad -&gt; <span class="dt">string</span> -&gt; <span class="dt">int</span> -&gt; &#39;a backtracking_monad</span>
-<span id="cb450-9"><a href="#cb450-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> satisfy : (<span class="dt">char</span> -&gt; <span class="dt">bool</span>) -&gt; <span class="dt">char</span> monad  <span class="co">(* Consume a character of the class *)</span></span>
-<span id="cb450-10"><a href="#cb450-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> end_of_text : <span class="dt">unit</span> monad  <span class="co">(* Check for end of the processed text *)</span></span>
-<span id="cb450-11"><a href="#cb450-11" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb450-12"><a href="#cb450-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb450-13"><a href="#cb450-13" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ParseT (MP : MONAD_PLUS_OPS) :</span>
-<span id="cb450-14"><a href="#cb450-14" aria-hidden="true" tabindex="-1"></a>  PARSE <span class="kw">with</span> <span class="kw">type</span> &#39;a backtracking_monad := &#39;a MP.monad =</span>
-<span id="cb450-15"><a href="#cb450-15" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span></span>
-<span id="cb450-16"><a href="#cb450-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a backtracking_monad = &#39;a MP.monad</span>
-<span id="cb450-17"><a href="#cb450-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a parsing_state = <span class="dt">int</span> -&gt; (&#39;a * <span class="dt">int</span>) MP.monad</span>
-<span id="cb450-18"><a href="#cb450-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> M = <span class="kw">struct</span></span>
-<span id="cb450-19"><a href="#cb450-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">type</span> &#39;a t = <span class="dt">string</span> -&gt; &#39;a parsing_state</span>
-<span id="cb450-20"><a href="#cb450-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> return a = <span class="kw">fun</span> s p -&gt; MP.return (a, p)</span>
-<span id="cb450-21"><a href="#cb450-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> bind m b = <span class="kw">fun</span> s p -&gt;</span>
-<span id="cb450-22"><a href="#cb450-22" aria-hidden="true" tabindex="-1"></a>      MP.bind (m s p) (<span class="kw">fun</span> (a, p&#39;) -&gt; b a s p&#39;)</span>
-<span id="cb450-23"><a href="#cb450-23" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> mzero = <span class="kw">fun</span> _ p -&gt; MP.mzero</span>
-<span id="cb450-24"><a href="#cb450-24" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> mplus ma mb = <span class="kw">fun</span> s p -&gt;</span>
-<span id="cb450-25"><a href="#cb450-25" aria-hidden="true" tabindex="-1"></a>      MP.mplus (ma s p) (<span class="kw">lazy</span> (<span class="dt">Lazy</span>.force mb s p))</span>
-<span id="cb450-26"><a href="#cb450-26" aria-hidden="true" tabindex="-1"></a>  <span class="kw">end</span></span>
-<span id="cb450-27"><a href="#cb450-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> M</span>
-<span id="cb450-28"><a href="#cb450-28" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> MonadPlusOps(M)</span>
-<span id="cb450-29"><a href="#cb450-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (&lt;|&gt;) ma mb = mplus ma mb</span>
-<span id="cb450-30"><a href="#cb450-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> runT m s p = MP.lift <span class="dt">fst</span> (m s p)</span>
-<span id="cb450-31"><a href="#cb450-31" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> satisfy f s p =</span>
-<span id="cb450-32"><a href="#cb450-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">if</span> p &lt; <span class="dt">String</span>.length s &amp;&amp; f s.[p]  <span class="co">(* Consuming a character means accessing it *)</span></span>
-<span id="cb450-33"><a href="#cb450-33" aria-hidden="true" tabindex="-1"></a>    <span class="kw">then</span> MP.return (s.[p], p + <span class="dv">1</span>) <span class="kw">else</span> MP.mzero  <span class="co">(* and advancing the parsing pos *)</span></span>
-<span id="cb450-34"><a href="#cb450-34" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> end_of_text s p =</span>
-<span id="cb450-35"><a href="#cb450-35" aria-hidden="true" tabindex="-1"></a>    <span class="kw">if</span> p &gt;= <span class="dt">String</span>.length s <span class="kw">then</span> MP.return ((), p) <span class="kw">else</span> MP.mzero</span>
-<span id="cb450-36"><a href="#cb450-36" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<div class="sourceCode" id="cb462"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb462-1"><a href="#cb462-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> PARSE = <span class="kw">sig</span></span>
+<span id="cb462-2"><a href="#cb462-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a backtracking_monad  <span class="co">(* Name for the underlying monad-plus *)</span></span>
+<span id="cb462-3"><a href="#cb462-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a parsing_state = <span class="dt">int</span> -&gt; (&#39;a * <span class="dt">int</span>) backtracking_monad  <span class="co">(* State: position *)</span></span>
+<span id="cb462-4"><a href="#cb462-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = <span class="dt">string</span> -&gt; &#39;a parsing_state  <span class="co">(* Reader for the parsed text *)</span></span>
+<span id="cb462-5"><a href="#cb462-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> MONAD_PLUS_OPS</span>
+<span id="cb462-6"><a href="#cb462-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (&lt;|&gt;) : &#39;a monad -&gt; &#39;a monad <span class="dt">Lazy</span>.t -&gt; &#39;a monad  <span class="co">(* A synonym for mplus *)</span></span>
+<span id="cb462-7"><a href="#cb462-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> run : &#39;a monad -&gt; &#39;a t</span>
+<span id="cb462-8"><a href="#cb462-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> runT : &#39;a monad -&gt; <span class="dt">string</span> -&gt; <span class="dt">int</span> -&gt; &#39;a backtracking_monad</span>
+<span id="cb462-9"><a href="#cb462-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> satisfy : (<span class="dt">char</span> -&gt; <span class="dt">bool</span>) -&gt; <span class="dt">char</span> monad  <span class="co">(* Consume a character of the class *)</span></span>
+<span id="cb462-10"><a href="#cb462-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> end_of_text : <span class="dt">unit</span> monad  <span class="co">(* Check for end of the processed text *)</span></span>
+<span id="cb462-11"><a href="#cb462-11" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb462-12"><a href="#cb462-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb462-13"><a href="#cb462-13" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ParseT (MP : MONAD_PLUS_OPS) :</span>
+<span id="cb462-14"><a href="#cb462-14" aria-hidden="true" tabindex="-1"></a>  PARSE <span class="kw">with</span> <span class="kw">type</span> &#39;a backtracking_monad := &#39;a MP.monad =</span>
+<span id="cb462-15"><a href="#cb462-15" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span></span>
+<span id="cb462-16"><a href="#cb462-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a backtracking_monad = &#39;a MP.monad</span>
+<span id="cb462-17"><a href="#cb462-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a parsing_state = <span class="dt">int</span> -&gt; (&#39;a * <span class="dt">int</span>) MP.monad</span>
+<span id="cb462-18"><a href="#cb462-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> M = <span class="kw">struct</span></span>
+<span id="cb462-19"><a href="#cb462-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">type</span> &#39;a t = <span class="dt">string</span> -&gt; &#39;a parsing_state</span>
+<span id="cb462-20"><a href="#cb462-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> return a = <span class="kw">fun</span> s p -&gt; MP.return (a, p)</span>
+<span id="cb462-21"><a href="#cb462-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> bind m b = <span class="kw">fun</span> s p -&gt;</span>
+<span id="cb462-22"><a href="#cb462-22" aria-hidden="true" tabindex="-1"></a>      MP.bind (m s p) (<span class="kw">fun</span> (a, p&#39;) -&gt; b a s p&#39;)</span>
+<span id="cb462-23"><a href="#cb462-23" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> mzero = <span class="kw">fun</span> _ p -&gt; MP.mzero</span>
+<span id="cb462-24"><a href="#cb462-24" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> mplus ma mb = <span class="kw">fun</span> s p -&gt;</span>
+<span id="cb462-25"><a href="#cb462-25" aria-hidden="true" tabindex="-1"></a>      MP.mplus (ma s p) (<span class="kw">lazy</span> (<span class="dt">Lazy</span>.force mb s p))</span>
+<span id="cb462-26"><a href="#cb462-26" aria-hidden="true" tabindex="-1"></a>  <span class="kw">end</span></span>
+<span id="cb462-27"><a href="#cb462-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> M</span>
+<span id="cb462-28"><a href="#cb462-28" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> MonadPlusOps(M)</span>
+<span id="cb462-29"><a href="#cb462-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (&lt;|&gt;) ma mb = mplus ma mb</span>
+<span id="cb462-30"><a href="#cb462-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> runT m s p = MP.lift <span class="dt">fst</span> (m s p)</span>
+<span id="cb462-31"><a href="#cb462-31" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> satisfy f s p =</span>
+<span id="cb462-32"><a href="#cb462-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">if</span> p &lt; <span class="dt">String</span>.length s &amp;&amp; f s.[p]  <span class="co">(* Consuming a character means accessing it *)</span></span>
+<span id="cb462-33"><a href="#cb462-33" aria-hidden="true" tabindex="-1"></a>    <span class="kw">then</span> MP.return (s.[p], p + <span class="dv">1</span>) <span class="kw">else</span> MP.mzero  <span class="co">(* and advancing the parsing pos *)</span></span>
+<span id="cb462-34"><a href="#cb462-34" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> end_of_text s p =</span>
+<span id="cb462-35"><a href="#cb462-35" aria-hidden="true" tabindex="-1"></a>    <span class="kw">if</span> p &gt;= <span class="dt">String</span>.length s <span class="kw">then</span> MP.return ((), p) <span class="kw">else</span> MP.mzero</span>
+<span id="cb462-36"><a href="#cb462-36" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <h3 id="additional-parser-operations">Additional Parser Operations</h3>
-<div class="sourceCode" id="cb451"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb451-1"><a href="#cb451-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> PARSE_OPS = <span class="kw">sig</span></span>
-<span id="cb451-2"><a href="#cb451-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> PARSE</span>
-<span id="cb451-3"><a href="#cb451-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> many : &#39;a monad -&gt; &#39;a <span class="dt">list</span> monad</span>
-<span id="cb451-4"><a href="#cb451-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> opt : &#39;a monad -&gt; &#39;a <span class="dt">option</span> monad</span>
-<span id="cb451-5"><a href="#cb451-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (?|) : &#39;a monad -&gt; &#39;a <span class="dt">option</span> monad</span>
-<span id="cb451-6"><a href="#cb451-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> seq : &#39;a monad -&gt; &#39;b monad <span class="dt">Lazy</span>.t -&gt; (&#39;a * &#39;b) monad  <span class="co">(* Exercise: why lazy? *)</span></span>
-<span id="cb451-7"><a href="#cb451-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (&lt;*&gt;) : &#39;a monad -&gt; &#39;b monad <span class="dt">Lazy</span>.t -&gt; (&#39;a * &#39;b) monad  <span class="co">(* Synonym for seq *)</span></span>
-<span id="cb451-8"><a href="#cb451-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> lowercase : <span class="dt">char</span> monad</span>
-<span id="cb451-9"><a href="#cb451-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> uppercase : <span class="dt">char</span> monad</span>
-<span id="cb451-10"><a href="#cb451-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> digit : <span class="dt">char</span> monad</span>
-<span id="cb451-11"><a href="#cb451-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> alpha : <span class="dt">char</span> monad</span>
-<span id="cb451-12"><a href="#cb451-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> alphanum : <span class="dt">char</span> monad</span>
-<span id="cb451-13"><a href="#cb451-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> literal : <span class="dt">string</span> -&gt; <span class="dt">unit</span> monad  <span class="co">(* Consume characters of the given string *)</span></span>
-<span id="cb451-14"><a href="#cb451-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (<span class="st">&lt;&lt;&gt;) : string -&gt; &#39;a monad -&gt; &#39;a monad  (* Prefix and postfix keywords *)</span></span>
-<span id="cb451-15"><a href="#cb451-15" aria-hidden="true" tabindex="-1"></a><span class="st">  val (&lt;&gt;&gt;</span>) : &#39;a monad -&gt; <span class="dt">string</span> -&gt; &#39;a monad</span>
-<span id="cb451-16"><a href="#cb451-16" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb451-17"><a href="#cb451-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb451-18"><a href="#cb451-18" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ParseOps (R : MONAD_PLUS_OPS)</span>
-<span id="cb451-19"><a href="#cb451-19" aria-hidden="true" tabindex="-1"></a>  (P : PARSE <span class="kw">with</span> <span class="kw">type</span> &#39;a backtracking_monad := &#39;a R.monad) :</span>
-<span id="cb451-20"><a href="#cb451-20" aria-hidden="true" tabindex="-1"></a>  PARSE_OPS <span class="kw">with</span> <span class="kw">type</span> &#39;a backtracking_monad := &#39;a R.monad =</span>
-<span id="cb451-21"><a href="#cb451-21" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span></span>
-<span id="cb451-22"><a href="#cb451-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> P</span>
-<span id="cb451-23"><a href="#cb451-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="kw">rec</span> many p =</span>
-<span id="cb451-24"><a href="#cb451-24" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">let</span>* r = p <span class="kw">in</span></span>
-<span id="cb451-25"><a href="#cb451-25" aria-hidden="true" tabindex="-1"></a>     <span class="kw">let</span>* rs = many p <span class="kw">in</span></span>
-<span id="cb451-26"><a href="#cb451-26" aria-hidden="true" tabindex="-1"></a>     return (r::rs))</span>
-<span id="cb451-27"><a href="#cb451-27" aria-hidden="true" tabindex="-1"></a>    ++ <span class="kw">lazy</span> (return [])</span>
-<span id="cb451-28"><a href="#cb451-28" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> opt p = (<span class="kw">let</span>* x = p <span class="kw">in</span> return (<span class="dt">Some</span> x)) ++ <span class="kw">lazy</span> (return <span class="dt">None</span>)</span>
-<span id="cb451-29"><a href="#cb451-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (?|) p = opt p</span>
-<span id="cb451-30"><a href="#cb451-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> seq p q =</span>
-<span id="cb451-31"><a href="#cb451-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span>* x = p <span class="kw">in</span></span>
-<span id="cb451-32"><a href="#cb451-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span>* y = <span class="dt">Lazy</span>.force q <span class="kw">in</span></span>
-<span id="cb451-33"><a href="#cb451-33" aria-hidden="true" tabindex="-1"></a>    return (x, y)</span>
-<span id="cb451-34"><a href="#cb451-34" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (&lt;*&gt;) p q = seq p q</span>
-<span id="cb451-35"><a href="#cb451-35" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> lowercase = satisfy (<span class="kw">fun</span> c -&gt; c &gt;= <span class="ch">&#39;a&#39;</span> &amp;&amp; c &lt;= <span class="ch">&#39;z&#39;</span>)</span>
-<span id="cb451-36"><a href="#cb451-36" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> uppercase = satisfy (<span class="kw">fun</span> c -&gt; c &gt;= <span class="ch">&#39;A&#39;</span> &amp;&amp; c &lt;= <span class="ch">&#39;Z&#39;</span>)</span>
-<span id="cb451-37"><a href="#cb451-37" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> digit = satisfy (<span class="kw">fun</span> c -&gt; c &gt;= <span class="ch">&#39;0&#39;</span> &amp;&amp; c &lt;= <span class="ch">&#39;9&#39;</span>)</span>
-<span id="cb451-38"><a href="#cb451-38" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> alpha = lowercase ++ <span class="kw">lazy</span> uppercase</span>
-<span id="cb451-39"><a href="#cb451-39" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> alphanum = alpha ++ <span class="kw">lazy</span> digit</span>
-<span id="cb451-40"><a href="#cb451-40" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> literal l =</span>
-<span id="cb451-41"><a href="#cb451-41" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> <span class="kw">rec</span> loop pos =</span>
-<span id="cb451-42"><a href="#cb451-42" aria-hidden="true" tabindex="-1"></a>      <span class="kw">if</span> pos = <span class="dt">String</span>.length l <span class="kw">then</span> return ()</span>
-<span id="cb451-43"><a href="#cb451-43" aria-hidden="true" tabindex="-1"></a>      <span class="kw">else</span> satisfy (<span class="kw">fun</span> c -&gt; c = l.[pos]) &gt;&gt;- loop (pos + <span class="dv">1</span>) <span class="kw">in</span></span>
-<span id="cb451-44"><a href="#cb451-44" aria-hidden="true" tabindex="-1"></a>    loop <span class="dv">0</span></span>
-<span id="cb451-45"><a href="#cb451-45" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (<span class="st">&lt;&lt;&gt;) bra p = literal bra &gt;&gt;</span>- p</span>
-<span id="cb451-46"><a href="#cb451-46" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (&lt;&gt;&gt;) p ket =</span>
-<span id="cb451-47"><a href="#cb451-47" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span>* x = p <span class="kw">in</span></span>
-<span id="cb451-48"><a href="#cb451-48" aria-hidden="true" tabindex="-1"></a>    literal ket &gt;&gt;- return x</span>
-<span id="cb451-49"><a href="#cb451-49" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
-<h2 id="parser-combinators-tying-the-recursive-knot">11.11 Parser
+<div class="sourceCode" id="cb463"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb463-1"><a href="#cb463-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> PARSE_OPS = <span class="kw">sig</span></span>
+<span id="cb463-2"><a href="#cb463-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> PARSE</span>
+<span id="cb463-3"><a href="#cb463-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> many : &#39;a monad -&gt; &#39;a <span class="dt">list</span> monad</span>
+<span id="cb463-4"><a href="#cb463-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> opt : &#39;a monad -&gt; &#39;a <span class="dt">option</span> monad</span>
+<span id="cb463-5"><a href="#cb463-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (?|) : &#39;a monad -&gt; &#39;a <span class="dt">option</span> monad</span>
+<span id="cb463-6"><a href="#cb463-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> seq : &#39;a monad -&gt; &#39;b monad <span class="dt">Lazy</span>.t -&gt; (&#39;a * &#39;b) monad  <span class="co">(* Exercise: why lazy? *)</span></span>
+<span id="cb463-7"><a href="#cb463-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (&lt;*&gt;) : &#39;a monad -&gt; &#39;b monad <span class="dt">Lazy</span>.t -&gt; (&#39;a * &#39;b) monad  <span class="co">(* Synonym for seq *)</span></span>
+<span id="cb463-8"><a href="#cb463-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> lowercase : <span class="dt">char</span> monad</span>
+<span id="cb463-9"><a href="#cb463-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> uppercase : <span class="dt">char</span> monad</span>
+<span id="cb463-10"><a href="#cb463-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> digit : <span class="dt">char</span> monad</span>
+<span id="cb463-11"><a href="#cb463-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> alpha : <span class="dt">char</span> monad</span>
+<span id="cb463-12"><a href="#cb463-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> alphanum : <span class="dt">char</span> monad</span>
+<span id="cb463-13"><a href="#cb463-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> literal : <span class="dt">string</span> -&gt; <span class="dt">unit</span> monad  <span class="co">(* Consume characters of the given string *)</span></span>
+<span id="cb463-14"><a href="#cb463-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> (<span class="st">&lt;&lt;&gt;) : string -&gt; &#39;a monad -&gt; &#39;a monad  (* Prefix and postfix keywords *)</span></span>
+<span id="cb463-15"><a href="#cb463-15" aria-hidden="true" tabindex="-1"></a><span class="st">  val (&lt;&gt;&gt;</span>) : &#39;a monad -&gt; <span class="dt">string</span> -&gt; &#39;a monad</span>
+<span id="cb463-16"><a href="#cb463-16" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb463-17"><a href="#cb463-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb463-18"><a href="#cb463-18" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ParseOps (R : MONAD_PLUS_OPS)</span>
+<span id="cb463-19"><a href="#cb463-19" aria-hidden="true" tabindex="-1"></a>  (P : PARSE <span class="kw">with</span> <span class="kw">type</span> &#39;a backtracking_monad := &#39;a R.monad) :</span>
+<span id="cb463-20"><a href="#cb463-20" aria-hidden="true" tabindex="-1"></a>  PARSE_OPS <span class="kw">with</span> <span class="kw">type</span> &#39;a backtracking_monad := &#39;a R.monad =</span>
+<span id="cb463-21"><a href="#cb463-21" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span></span>
+<span id="cb463-22"><a href="#cb463-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">include</span> P</span>
+<span id="cb463-23"><a href="#cb463-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="kw">rec</span> many p =</span>
+<span id="cb463-24"><a href="#cb463-24" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">let</span>* r = p <span class="kw">in</span></span>
+<span id="cb463-25"><a href="#cb463-25" aria-hidden="true" tabindex="-1"></a>     <span class="kw">let</span>* rs = many p <span class="kw">in</span></span>
+<span id="cb463-26"><a href="#cb463-26" aria-hidden="true" tabindex="-1"></a>     return (r::rs))</span>
+<span id="cb463-27"><a href="#cb463-27" aria-hidden="true" tabindex="-1"></a>    ++ <span class="kw">lazy</span> (return [])</span>
+<span id="cb463-28"><a href="#cb463-28" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> opt p = (<span class="kw">let</span>* x = p <span class="kw">in</span> return (<span class="dt">Some</span> x)) ++ <span class="kw">lazy</span> (return <span class="dt">None</span>)</span>
+<span id="cb463-29"><a href="#cb463-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (?|) p = opt p</span>
+<span id="cb463-30"><a href="#cb463-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> seq p q =</span>
+<span id="cb463-31"><a href="#cb463-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span>* x = p <span class="kw">in</span></span>
+<span id="cb463-32"><a href="#cb463-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span>* y = <span class="dt">Lazy</span>.force q <span class="kw">in</span></span>
+<span id="cb463-33"><a href="#cb463-33" aria-hidden="true" tabindex="-1"></a>    return (x, y)</span>
+<span id="cb463-34"><a href="#cb463-34" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (&lt;*&gt;) p q = seq p q</span>
+<span id="cb463-35"><a href="#cb463-35" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> lowercase = satisfy (<span class="kw">fun</span> c -&gt; c &gt;= <span class="ch">&#39;a&#39;</span> &amp;&amp; c &lt;= <span class="ch">&#39;z&#39;</span>)</span>
+<span id="cb463-36"><a href="#cb463-36" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> uppercase = satisfy (<span class="kw">fun</span> c -&gt; c &gt;= <span class="ch">&#39;A&#39;</span> &amp;&amp; c &lt;= <span class="ch">&#39;Z&#39;</span>)</span>
+<span id="cb463-37"><a href="#cb463-37" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> digit = satisfy (<span class="kw">fun</span> c -&gt; c &gt;= <span class="ch">&#39;0&#39;</span> &amp;&amp; c &lt;= <span class="ch">&#39;9&#39;</span>)</span>
+<span id="cb463-38"><a href="#cb463-38" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> alpha = lowercase ++ <span class="kw">lazy</span> uppercase</span>
+<span id="cb463-39"><a href="#cb463-39" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> alphanum = alpha ++ <span class="kw">lazy</span> digit</span>
+<span id="cb463-40"><a href="#cb463-40" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> literal l =</span>
+<span id="cb463-41"><a href="#cb463-41" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span> <span class="kw">rec</span> loop pos =</span>
+<span id="cb463-42"><a href="#cb463-42" aria-hidden="true" tabindex="-1"></a>      <span class="kw">if</span> pos = <span class="dt">String</span>.length l <span class="kw">then</span> return ()</span>
+<span id="cb463-43"><a href="#cb463-43" aria-hidden="true" tabindex="-1"></a>      <span class="kw">else</span> satisfy (<span class="kw">fun</span> c -&gt; c = l.[pos]) &gt;&gt;- loop (pos + <span class="dv">1</span>) <span class="kw">in</span></span>
+<span id="cb463-44"><a href="#cb463-44" aria-hidden="true" tabindex="-1"></a>    loop <span class="dv">0</span></span>
+<span id="cb463-45"><a href="#cb463-45" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (<span class="st">&lt;&lt;&gt;) bra p = literal bra &gt;&gt;</span>- p</span>
+<span id="cb463-46"><a href="#cb463-46" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> (&lt;&gt;&gt;) p ket =</span>
+<span id="cb463-47"><a href="#cb463-47" aria-hidden="true" tabindex="-1"></a>    <span class="kw">let</span>* x = p <span class="kw">in</span></span>
+<span id="cb463-48"><a href="#cb463-48" aria-hidden="true" tabindex="-1"></a>    literal ket &gt;&gt;- return x</span>
+<span id="cb463-49"><a href="#cb463-49" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<h2 id="parser-combinators-tying-the-recursive-knot">11.12 Parser
 Combinators: Tying the Recursive Knot</h2>
 <p>Now we come to the key insight connecting parser combinators to the
 expression problem: how do we allow the grammar to be extended
 dynamically? The answer is to use a mutable reference holding a list of
 grammar rules, and tie the recursive knot lazily.</p>
 <p>File <code>PluginBase.ml</code>:</p>
-<div class="sourceCode" id="cb452"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb452-1"><a href="#cb452-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ParseM = ParseOps (LListM) (ParseT (LListM))</span>
-<span id="cb452-2"><a href="#cb452-2" aria-hidden="true" tabindex="-1"></a><span class="kw">open</span> ParseM</span>
-<span id="cb452-3"><a href="#cb452-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb452-4"><a href="#cb452-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> grammar_rules : (<span class="dt">int</span> monad -&gt; <span class="dt">int</span> monad) <span class="dt">list</span> <span class="dt">ref</span> = <span class="dt">ref</span> []</span>
-<span id="cb452-5"><a href="#cb452-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb452-6"><a href="#cb452-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> get_language () : <span class="dt">int</span> monad =</span>
-<span id="cb452-7"><a href="#cb452-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="kw">rec</span> <span class="dt">result</span> =</span>
-<span id="cb452-8"><a href="#cb452-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">lazy</span></span>
-<span id="cb452-9"><a href="#cb452-9" aria-hidden="true" tabindex="-1"></a>      (<span class="dt">List</span>.fold_left</span>
-<span id="cb452-10"><a href="#cb452-10" aria-hidden="true" tabindex="-1"></a>         (<span class="kw">fun</span> acc lang -&gt; acc &lt;|&gt; <span class="kw">lazy</span> (lang (<span class="dt">Lazy</span>.force <span class="dt">result</span>)))</span>
-<span id="cb452-11"><a href="#cb452-11" aria-hidden="true" tabindex="-1"></a>          mzero !grammar_rules) <span class="kw">in</span></span>
-<span id="cb452-12"><a href="#cb452-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* r = <span class="dt">Lazy</span>.force <span class="dt">result</span> <span class="kw">in</span></span>
-<span id="cb452-13"><a href="#cb452-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = end_of_text <span class="kw">in</span> return r  <span class="co">(* Ensure we parse the whole text *)</span></span></code></pre></div>
-<h2 id="parser-combinators-dynamic-code-loading">11.12 Parser
+<div class="sourceCode" id="cb464"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb464-1"><a href="#cb464-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ParseM = ParseOps (LListM) (ParseT (LListM))</span>
+<span id="cb464-2"><a href="#cb464-2" aria-hidden="true" tabindex="-1"></a><span class="kw">open</span> ParseM</span>
+<span id="cb464-3"><a href="#cb464-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb464-4"><a href="#cb464-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> grammar_rules : (<span class="dt">int</span> monad -&gt; <span class="dt">int</span> monad) <span class="dt">list</span> <span class="dt">ref</span> = <span class="dt">ref</span> []</span>
+<span id="cb464-5"><a href="#cb464-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb464-6"><a href="#cb464-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> get_language () : <span class="dt">int</span> monad =</span>
+<span id="cb464-7"><a href="#cb464-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="kw">rec</span> <span class="dt">result</span> =</span>
+<span id="cb464-8"><a href="#cb464-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">lazy</span></span>
+<span id="cb464-9"><a href="#cb464-9" aria-hidden="true" tabindex="-1"></a>      (<span class="dt">List</span>.fold_left</span>
+<span id="cb464-10"><a href="#cb464-10" aria-hidden="true" tabindex="-1"></a>         (<span class="kw">fun</span> acc lang -&gt; acc &lt;|&gt; <span class="kw">lazy</span> (lang (<span class="dt">Lazy</span>.force <span class="dt">result</span>)))</span>
+<span id="cb464-11"><a href="#cb464-11" aria-hidden="true" tabindex="-1"></a>          mzero !grammar_rules) <span class="kw">in</span></span>
+<span id="cb464-12"><a href="#cb464-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* r = <span class="dt">Lazy</span>.force <span class="dt">result</span> <span class="kw">in</span></span>
+<span id="cb464-13"><a href="#cb464-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = end_of_text <span class="kw">in</span> return r  <span class="co">(* Ensure we parse the whole text *)</span></span></code></pre></div>
+<h2 id="parser-combinators-dynamic-code-loading">11.13 Parser
 Combinators: Dynamic Code Loading</h2>
 <p>OCaml supports dynamic code loading through the <code>Dynlink</code>
 module. This allows us to load compiled modules at runtime, which can
@@ -15515,76 +15739,76 @@ register new grammar rules by mutating the <code>grammar_rules</code>
 reference. This is a powerful form of extensibility: we can add new
 syntax to our language without recompiling the main program.</p>
 <p>File <code>PluginRun.ml</code>:</p>
-<div class="sourceCode" id="cb453"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb453-1"><a href="#cb453-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> load_plug fname : <span class="dt">unit</span> =</span>
-<span id="cb453-2"><a href="#cb453-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> fname = Dynlink.adapt_filename fname <span class="kw">in</span></span>
-<span id="cb453-3"><a href="#cb453-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">if</span> <span class="dt">Sys</span>.file_exists fname <span class="kw">then</span></span>
-<span id="cb453-4"><a href="#cb453-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">try</span> Dynlink.loadfile fname</span>
-<span id="cb453-5"><a href="#cb453-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">with</span></span>
-<span id="cb453-6"><a href="#cb453-6" aria-hidden="true" tabindex="-1"></a>    | (Dynlink.<span class="dt">Error</span> err) <span class="kw">as</span> e -&gt;</span>
-<span id="cb453-7"><a href="#cb453-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">ERROR loading plugin: %s</span><span class="ch">\n</span><span class="st">%!&quot;</span></span>
-<span id="cb453-8"><a href="#cb453-8" aria-hidden="true" tabindex="-1"></a>        (Dynlink.error_message err);</span>
-<span id="cb453-9"><a href="#cb453-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">raise</span> e</span>
-<span id="cb453-10"><a href="#cb453-10" aria-hidden="true" tabindex="-1"></a>    | e -&gt; <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Unknow error while loading plugin</span><span class="ch">\n</span><span class="st">%!&quot;</span></span>
-<span id="cb453-11"><a href="#cb453-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">else</span> (</span>
-<span id="cb453-12"><a href="#cb453-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Plugin file %s does not exist</span><span class="ch">\n</span><span class="st">%!&quot;</span> fname;</span>
-<span id="cb453-13"><a href="#cb453-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">exit</span> (<span class="dv">-1</span>))</span>
-<span id="cb453-14"><a href="#cb453-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb453-15"><a href="#cb453-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
-<span id="cb453-16"><a href="#cb453-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">for</span> i = <span class="dv">2</span> <span class="kw">to</span> <span class="dt">Array</span>.length <span class="dt">Sys</span>.argv - <span class="dv">1</span> <span class="kw">do</span></span>
-<span id="cb453-17"><a href="#cb453-17" aria-hidden="true" tabindex="-1"></a>    load_plug <span class="dt">Sys</span>.argv.(i) <span class="kw">done</span>;</span>
-<span id="cb453-18"><a href="#cb453-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> lang = PluginBase.get_language () <span class="kw">in</span></span>
-<span id="cb453-19"><a href="#cb453-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="dt">result</span> =</span>
-<span id="cb453-20"><a href="#cb453-20" aria-hidden="true" tabindex="-1"></a>    Monad.LListM.run</span>
-<span id="cb453-21"><a href="#cb453-21" aria-hidden="true" tabindex="-1"></a>      (PluginBase.ParseM.runT lang <span class="dt">Sys</span>.argv.(<span class="dv">1</span>) <span class="dv">0</span>) <span class="kw">in</span></span>
-<span id="cb453-22"><a href="#cb453-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">match</span> Monad.ltake <span class="dv">1</span> <span class="dt">result</span> <span class="kw">with</span></span>
-<span id="cb453-23"><a href="#cb453-23" aria-hidden="true" tabindex="-1"></a>  | [] -&gt; <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Parse error</span><span class="ch">\n</span><span class="st">%!&quot;</span></span>
-<span id="cb453-24"><a href="#cb453-24" aria-hidden="true" tabindex="-1"></a>  | r::_ -&gt; <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Result: %d</span><span class="ch">\n</span><span class="st">%!&quot;</span> r</span></code></pre></div>
-<h2 id="parser-combinators-toy-example">11.13 Parser Combinators: Toy
+<div class="sourceCode" id="cb465"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb465-1"><a href="#cb465-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> load_plug fname : <span class="dt">unit</span> =</span>
+<span id="cb465-2"><a href="#cb465-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> fname = Dynlink.adapt_filename fname <span class="kw">in</span></span>
+<span id="cb465-3"><a href="#cb465-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">if</span> <span class="dt">Sys</span>.file_exists fname <span class="kw">then</span></span>
+<span id="cb465-4"><a href="#cb465-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">try</span> Dynlink.loadfile fname</span>
+<span id="cb465-5"><a href="#cb465-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">with</span></span>
+<span id="cb465-6"><a href="#cb465-6" aria-hidden="true" tabindex="-1"></a>    | (Dynlink.<span class="dt">Error</span> err) <span class="kw">as</span> e -&gt;</span>
+<span id="cb465-7"><a href="#cb465-7" aria-hidden="true" tabindex="-1"></a>      <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">ERROR loading plugin: %s</span><span class="ch">\n</span><span class="st">%!&quot;</span></span>
+<span id="cb465-8"><a href="#cb465-8" aria-hidden="true" tabindex="-1"></a>        (Dynlink.error_message err);</span>
+<span id="cb465-9"><a href="#cb465-9" aria-hidden="true" tabindex="-1"></a>      <span class="dt">raise</span> e</span>
+<span id="cb465-10"><a href="#cb465-10" aria-hidden="true" tabindex="-1"></a>    | e -&gt; <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Unknow error while loading plugin</span><span class="ch">\n</span><span class="st">%!&quot;</span></span>
+<span id="cb465-11"><a href="#cb465-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">else</span> (</span>
+<span id="cb465-12"><a href="#cb465-12" aria-hidden="true" tabindex="-1"></a>    <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Plugin file %s does not exist</span><span class="ch">\n</span><span class="st">%!&quot;</span> fname;</span>
+<span id="cb465-13"><a href="#cb465-13" aria-hidden="true" tabindex="-1"></a>    <span class="dt">exit</span> (<span class="dv">-1</span>))</span>
+<span id="cb465-14"><a href="#cb465-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb465-15"><a href="#cb465-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
+<span id="cb465-16"><a href="#cb465-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">for</span> i = <span class="dv">2</span> <span class="kw">to</span> <span class="dt">Array</span>.length <span class="dt">Sys</span>.argv - <span class="dv">1</span> <span class="kw">do</span></span>
+<span id="cb465-17"><a href="#cb465-17" aria-hidden="true" tabindex="-1"></a>    load_plug <span class="dt">Sys</span>.argv.(i) <span class="kw">done</span>;</span>
+<span id="cb465-18"><a href="#cb465-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> lang = PluginBase.get_language () <span class="kw">in</span></span>
+<span id="cb465-19"><a href="#cb465-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="dt">result</span> =</span>
+<span id="cb465-20"><a href="#cb465-20" aria-hidden="true" tabindex="-1"></a>    Monad.LListM.run</span>
+<span id="cb465-21"><a href="#cb465-21" aria-hidden="true" tabindex="-1"></a>      (PluginBase.ParseM.runT lang <span class="dt">Sys</span>.argv.(<span class="dv">1</span>) <span class="dv">0</span>) <span class="kw">in</span></span>
+<span id="cb465-22"><a href="#cb465-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">match</span> Monad.ltake <span class="dv">1</span> <span class="dt">result</span> <span class="kw">with</span></span>
+<span id="cb465-23"><a href="#cb465-23" aria-hidden="true" tabindex="-1"></a>  | [] -&gt; <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Parse error</span><span class="ch">\n</span><span class="st">%!&quot;</span></span>
+<span id="cb465-24"><a href="#cb465-24" aria-hidden="true" tabindex="-1"></a>  | r::_ -&gt; <span class="dt">Printf</span>.printf <span class="st">&quot;</span><span class="ch">\n</span><span class="st">Result: %d</span><span class="ch">\n</span><span class="st">%!&quot;</span> r</span></code></pre></div>
+<h2 id="parser-combinators-toy-example">11.14 Parser Combinators: Toy
 Example</h2>
 <p>Let us see how this works with a concrete example. We will define two
 plugins: one for parsing numbers and addition, and another for parsing
 multiplication. Each plugin registers its grammar rules by appending to
 the <code>grammar_rules</code> list.</p>
 <p>File <code>Plugin1.ml</code>:</p>
-<div class="sourceCode" id="cb454"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb454-1"><a href="#cb454-1" aria-hidden="true" tabindex="-1"></a><span class="kw">open</span> ParseM</span>
-<span id="cb454-2"><a href="#cb454-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> digit_of_char d = <span class="dt">int_of_char</span> d - <span class="dt">int_of_char</span> <span class="ch">&#39;0&#39;</span></span>
-<span id="cb454-3"><a href="#cb454-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb454-4"><a href="#cb454-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> number _ =  <span class="co">(* Numbers: N := D N | D where D is digits *)</span></span>
-<span id="cb454-5"><a href="#cb454-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="kw">rec</span> num =  <span class="co">(* Note: we avoid left-recursion by having the digit first *)</span></span>
-<span id="cb454-6"><a href="#cb454-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">lazy</span> ((<span class="kw">let</span>* d = digit <span class="kw">in</span></span>
-<span id="cb454-7"><a href="#cb454-7" aria-hidden="true" tabindex="-1"></a>           <span class="kw">let</span>* (n, b) = <span class="dt">Lazy</span>.force num <span class="kw">in</span></span>
-<span id="cb454-8"><a href="#cb454-8" aria-hidden="true" tabindex="-1"></a>           return (digit_of_char d * b + n, b * <span class="dv">10</span>))</span>
-<span id="cb454-9"><a href="#cb454-9" aria-hidden="true" tabindex="-1"></a>      &lt;|&gt; <span class="kw">lazy</span> (<span class="kw">let</span>* d = digit <span class="kw">in</span> return (digit_of_char d, <span class="dv">10</span>))) <span class="kw">in</span></span>
-<span id="cb454-10"><a href="#cb454-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">Lazy</span>.force num &gt;&gt;| <span class="dt">fst</span></span>
-<span id="cb454-11"><a href="#cb454-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb454-12"><a href="#cb454-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> addition lang =  <span class="co">(* Addition rule: S -&gt; (S + S) *)</span></span>
-<span id="cb454-13"><a href="#cb454-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* Requiring a parenthesis &#39;(&#39; turns the rule into non-left-recursive *)</span></span>
-<span id="cb454-14"><a href="#cb454-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* because we consume a character before recursing *)</span></span>
-<span id="cb454-15"><a href="#cb454-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;(&quot;</span> <span class="kw">in</span></span>
-<span id="cb454-16"><a href="#cb454-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n1 = lang <span class="kw">in</span></span>
-<span id="cb454-17"><a href="#cb454-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;+&quot;</span> <span class="kw">in</span></span>
-<span id="cb454-18"><a href="#cb454-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n2 = lang <span class="kw">in</span></span>
-<span id="cb454-19"><a href="#cb454-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;)&quot;</span> <span class="kw">in</span></span>
-<span id="cb454-20"><a href="#cb454-20" aria-hidden="true" tabindex="-1"></a>  return (n1 + n2)</span>
-<span id="cb454-21"><a href="#cb454-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb454-22"><a href="#cb454-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = grammar_rules := number :: addition :: !grammar_rules</span></code></pre></div>
+<div class="sourceCode" id="cb466"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb466-1"><a href="#cb466-1" aria-hidden="true" tabindex="-1"></a><span class="kw">open</span> ParseM</span>
+<span id="cb466-2"><a href="#cb466-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> digit_of_char d = <span class="dt">int_of_char</span> d - <span class="dt">int_of_char</span> <span class="ch">&#39;0&#39;</span></span>
+<span id="cb466-3"><a href="#cb466-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb466-4"><a href="#cb466-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> number _ =  <span class="co">(* Numbers: N := D N | D where D is digits *)</span></span>
+<span id="cb466-5"><a href="#cb466-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> <span class="kw">rec</span> num =  <span class="co">(* Note: we avoid left-recursion by having the digit first *)</span></span>
+<span id="cb466-6"><a href="#cb466-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">lazy</span> ((<span class="kw">let</span>* d = digit <span class="kw">in</span></span>
+<span id="cb466-7"><a href="#cb466-7" aria-hidden="true" tabindex="-1"></a>           <span class="kw">let</span>* (n, b) = <span class="dt">Lazy</span>.force num <span class="kw">in</span></span>
+<span id="cb466-8"><a href="#cb466-8" aria-hidden="true" tabindex="-1"></a>           return (digit_of_char d * b + n, b * <span class="dv">10</span>))</span>
+<span id="cb466-9"><a href="#cb466-9" aria-hidden="true" tabindex="-1"></a>      &lt;|&gt; <span class="kw">lazy</span> (<span class="kw">let</span>* d = digit <span class="kw">in</span> return (digit_of_char d, <span class="dv">10</span>))) <span class="kw">in</span></span>
+<span id="cb466-10"><a href="#cb466-10" aria-hidden="true" tabindex="-1"></a>  <span class="dt">Lazy</span>.force num &gt;&gt;| <span class="dt">fst</span></span>
+<span id="cb466-11"><a href="#cb466-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb466-12"><a href="#cb466-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> addition lang =  <span class="co">(* Addition rule: S -&gt; (S + S) *)</span></span>
+<span id="cb466-13"><a href="#cb466-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* Requiring a parenthesis &#39;(&#39; turns the rule into non-left-recursive *)</span></span>
+<span id="cb466-14"><a href="#cb466-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* because we consume a character before recursing *)</span></span>
+<span id="cb466-15"><a href="#cb466-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;(&quot;</span> <span class="kw">in</span></span>
+<span id="cb466-16"><a href="#cb466-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n1 = lang <span class="kw">in</span></span>
+<span id="cb466-17"><a href="#cb466-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;+&quot;</span> <span class="kw">in</span></span>
+<span id="cb466-18"><a href="#cb466-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n2 = lang <span class="kw">in</span></span>
+<span id="cb466-19"><a href="#cb466-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;)&quot;</span> <span class="kw">in</span></span>
+<span id="cb466-20"><a href="#cb466-20" aria-hidden="true" tabindex="-1"></a>  return (n1 + n2)</span>
+<span id="cb466-21"><a href="#cb466-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb466-22"><a href="#cb466-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = grammar_rules := number :: addition :: !grammar_rules</span></code></pre></div>
 <p>File <code>Plugin2.ml</code> adds multiplication to the language.
 Notice how we can add this functionality without modifying any existing
 code:</p>
-<div class="sourceCode" id="cb455"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb455-1"><a href="#cb455-1" aria-hidden="true" tabindex="-1"></a><span class="kw">open</span> ParseM</span>
-<span id="cb455-2"><a href="#cb455-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb455-3"><a href="#cb455-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> multiplication lang =  <span class="co">(* Multiplication rule: S -&gt; (S * S) *)</span></span>
-<span id="cb455-4"><a href="#cb455-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;(&quot;</span> <span class="kw">in</span></span>
-<span id="cb455-5"><a href="#cb455-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n1 = lang <span class="kw">in</span></span>
-<span id="cb455-6"><a href="#cb455-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;*&quot;</span> <span class="kw">in</span></span>
-<span id="cb455-7"><a href="#cb455-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n2 = lang <span class="kw">in</span></span>
-<span id="cb455-8"><a href="#cb455-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;)&quot;</span> <span class="kw">in</span></span>
-<span id="cb455-9"><a href="#cb455-9" aria-hidden="true" tabindex="-1"></a>  return (n1 * n2)</span>
-<span id="cb455-10"><a href="#cb455-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb455-11"><a href="#cb455-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = grammar_rules := multiplication :: !grammar_rules</span></code></pre></div>
+<div class="sourceCode" id="cb467"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb467-1"><a href="#cb467-1" aria-hidden="true" tabindex="-1"></a><span class="kw">open</span> ParseM</span>
+<span id="cb467-2"><a href="#cb467-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb467-3"><a href="#cb467-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> multiplication lang =  <span class="co">(* Multiplication rule: S -&gt; (S * S) *)</span></span>
+<span id="cb467-4"><a href="#cb467-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;(&quot;</span> <span class="kw">in</span></span>
+<span id="cb467-5"><a href="#cb467-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n1 = lang <span class="kw">in</span></span>
+<span id="cb467-6"><a href="#cb467-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;*&quot;</span> <span class="kw">in</span></span>
+<span id="cb467-7"><a href="#cb467-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* n2 = lang <span class="kw">in</span></span>
+<span id="cb467-8"><a href="#cb467-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span>* () = literal <span class="st">&quot;)&quot;</span> <span class="kw">in</span></span>
+<span id="cb467-9"><a href="#cb467-9" aria-hidden="true" tabindex="-1"></a>  return (n1 * n2)</span>
+<span id="cb467-10"><a href="#cb467-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb467-11"><a href="#cb467-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = grammar_rules := multiplication :: !grammar_rules</span></code></pre></div>
 <h3 id="chapter-summary-what-to-remember">Chapter Summary (What to
 Remember)</h3>
 <ul>
@@ -15594,6 +15818,11 @@ keeping separate compilation and static typing.</li>
 <li>Ordinary ADTs make new operations easy and new cases hard; OO makes
 new cases easy and new operations hard; extensible variants make new
 cases easy but weaken exhaustiveness guarantees.</li>
+<li>Extensible GADTs (<code>type _ expr = ..</code>) add type-level
+precision: each constructor carries a result-type index the compiler
+tracks. However, OCaml still cannot check exhaustiveness for open types,
+so the same runtime-failure risk as plain extensible variants remains.
+They are a stronger, but still incomplete, non-solution.</li>
 <li>Polymorphic variants (especially with recursive modules) support a
 pragmatic “structural” style of extension: you can grow a language in
 separate files with less tagging boilerplate, at the cost of more
@@ -15603,7 +15832,7 @@ a language combinator library: you extend the language by adding new
 combinators/rules, and dynamic loading makes the modularity aspect very
 concrete.</li>
 </ul>
-<h2 id="exercises-10">11.14 Exercises</h2>
+<h2 id="exercises-10">11.15 Exercises</h2>
 <p>The following exercises will help you deepen your understanding of
 the expression problem and the various solutions we have explored. They
 range from implementing additional operations to refactoring the code
@@ -15709,6 +15938,43 @@ lazy-monad-plus and odd lazy lists.</li>
 is lazy. In an “even” lazy list, the entire list is wrapped in laziness.
 The choice affects when computation happens and how infinite structures
 are handled.)</p>
+<h3 id="exercise-14-extensible-gadt-pretty-printer">Exercise 14:
+Extensible GADT Pretty-Printer</h3>
+<p>Using the extensible GADT infrastructure from
+<code>chapter11/ExtGADT.ml</code> (section 11.9):</p>
+<ol type="1">
+<li>The existing <code>eval_layer</code> type is
+<code>{ layer : 'a. eval_chain -&gt; 'a expr -&gt; 'a option }</code> —
+the return type varies with the expression’s type index. A
+pretty-printer always returns <code>string</code>, so it cannot reuse
+<code>eval_layer</code> directly. Define new record types
+<code>string_chain</code> and <code>string_layer</code> analogous to
+<code>eval_chain</code> and <code>eval_layer</code>, where the handler
+always returns <code>string option</code> regardless of the expression’s
+type index. Then implement <code>arith_string_layer</code> and
+<code>bool_string_layer</code> that convert arithmetic and boolean
+expressions to strings, using the <code>string_chain</code> for
+recursive calls.</li>
+<li>Write a <code>build_string_eval</code> function (analogous to
+<code>build_eval</code>) that ties the open-recursion knot for
+<code>string_layer</code> values, producing a <code>string_chain</code>.
+Compose your layers to obtain a complete
+<code>string_of_expr : 'a expr -&gt; string</code>. Test it on
+expressions like <code>Add (Num 2, Num 3)</code> and
+<code>Gt (Num 1, Num 0)</code>.</li>
+<li>Now compose the pretty-printer with the arithmetic evaluator: build
+a program that uses both <code>build_eval</code> (with
+<code>arith_layer</code> and <code>bool_layer</code>) and
+<code>build_string_eval</code> (with your string layers) on the same
+expressions. Observe that the two operations require separate
+composition pipelines.</li>
+<li>Identify which parts of the <code>build_eval</code> boilerplate had
+to be duplicated for <code>build_string_eval</code> (the mutable
+reference, the <code>List.find_map</code> loop, the initialization). Is
+this duplication acceptable, or does it suggest a further abstraction?
+Optionally, factor the common pattern into a functor or higher-order
+function parameterized by the chain and layer types.</li>
+</ol>
 <h1 id="chapter-12-categories-and-gadts">Chapter 12: Categories and
 GADTs</h1>
 <figure>
@@ -15795,50 +16061,50 @@ functions <code>'a -&gt; 'b</code> are morphisms, <code>Fun.id</code> is
 the identity, and <code>Fun.compose</code> (or <code>( -| )</code>) is
 composition. The laws hold because function composition is associative
 and <code>Fun.id</code> is a unit:</p>
-<div class="sourceCode" id="cb456"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb456-1"><a href="#cb456-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> id x = x</span>
-<span id="cb456-2"><a href="#cb456-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> compose f g x = f (g x)</span>
-<span id="cb456-3"><a href="#cb456-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb456-4"><a href="#cb456-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* Laws (we test on a specific case): *)</span></span>
-<span id="cb456-5"><a href="#cb456-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x + <span class="dv">1</span></span>
-<span id="cb456-6"><a href="#cb456-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = x * <span class="dv">2</span></span>
-<span id="cb456-7"><a href="#cb456-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> h x = x - <span class="dv">3</span></span>
-<span id="cb456-8"><a href="#cb456-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> x = <span class="dv">7</span></span>
-<span id="cb456-9"><a href="#cb456-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb456-10"><a href="#cb456-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose id f x = f x)          <span class="co">(* left identity *)</span></span>
-<span id="cb456-11"><a href="#cb456-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose f id x = f x)          <span class="co">(* right identity *)</span></span>
-<span id="cb456-12"><a href="#cb456-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose h (compose g f) x       <span class="co">(* associativity *)</span></span>
-<span id="cb456-13"><a href="#cb456-13" aria-hidden="true" tabindex="-1"></a>               = compose (compose h g) f x)</span></code></pre></div>
+<div class="sourceCode" id="cb468"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb468-1"><a href="#cb468-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> id x = x</span>
+<span id="cb468-2"><a href="#cb468-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> compose f g x = f (g x)</span>
+<span id="cb468-3"><a href="#cb468-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb468-4"><a href="#cb468-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* Laws (we test on a specific case): *)</span></span>
+<span id="cb468-5"><a href="#cb468-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x + <span class="dv">1</span></span>
+<span id="cb468-6"><a href="#cb468-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = x * <span class="dv">2</span></span>
+<span id="cb468-7"><a href="#cb468-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> h x = x - <span class="dv">3</span></span>
+<span id="cb468-8"><a href="#cb468-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> x = <span class="dv">7</span></span>
+<span id="cb468-9"><a href="#cb468-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb468-10"><a href="#cb468-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose id f x = f x)          <span class="co">(* left identity *)</span></span>
+<span id="cb468-11"><a href="#cb468-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose f id x = f x)          <span class="co">(* right identity *)</span></span>
+<span id="cb468-12"><a href="#cb468-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose h (compose g f) x       <span class="co">(* associativity *)</span></span>
+<span id="cb468-13"><a href="#cb468-13" aria-hidden="true" tabindex="-1"></a>               = compose (compose h g) f x)</span></code></pre></div>
 <p><strong>A poset as a category.</strong> Any partially ordered set
 <span class="math inline">(S, \leq)</span> forms a category where
 objects are elements of <span class="math inline">S</span>, there is
 exactly one morphism <span class="math inline">a \to b</span> when <span
 class="math inline">a \leq b</span>, and none otherwise. Composition is
 transitivity; identity is reflexivity:</p>
-<div class="sourceCode" id="cb457"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb457-1"><a href="#cb457-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The poset (int, &lt;=) as a category: *)</span></span>
-<span id="cb457-2"><a href="#cb457-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Objects: integers *)</span></span>
-<span id="cb457-3"><a href="#cb457-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Morphisms: a single &quot;witness&quot; when a &lt;= b *)</span></span>
-<span id="cb457-4"><a href="#cb457-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Composition: transitivity of &lt;= *)</span></span>
-<span id="cb457-5"><a href="#cb457-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb457-6"><a href="#cb457-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* We encode natural numbers as Peano types at the type level: *)</span></span>
-<span id="cb457-7"><a href="#cb457-7" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> zero = Zero</span>
-<span id="cb457-8"><a href="#cb457-8" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;n <span class="dt">succ</span> = Succ</span>
-<span id="cb457-9"><a href="#cb457-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb457-10"><a href="#cb457-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* A witness that n &lt;= m: *)</span></span>
-<span id="cb457-11"><a href="#cb457-11" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (_, _) leq =</span>
-<span id="cb457-12"><a href="#cb457-12" aria-hidden="true" tabindex="-1"></a>  | Le_refl : (&#39;n, &#39;n) leq                       <span class="co">(* n &lt;= n *)</span></span>
-<span id="cb457-13"><a href="#cb457-13" aria-hidden="true" tabindex="-1"></a>  | Le_step : (&#39;n, &#39;m) leq -&gt; (&#39;n, &#39;m <span class="dt">succ</span>) leq  <span class="co">(* n &lt;= m implies n &lt;= m+1 *)</span></span>
-<span id="cb457-14"><a href="#cb457-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb457-15"><a href="#cb457-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Composition = transitivity: if a &lt;= b and b &lt;= c then a &lt;= c *)</span></span>
-<span id="cb457-16"><a href="#cb457-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> leq_trans : <span class="kw">type</span> a b c. (a, b) leq -&gt; (b, c) leq -&gt; (a, c) leq =</span>
-<span id="cb457-17"><a href="#cb457-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> p q -&gt; <span class="kw">match</span> q <span class="kw">with</span></span>
-<span id="cb457-18"><a href="#cb457-18" aria-hidden="true" tabindex="-1"></a>  | Le_refl -&gt; p</span>
-<span id="cb457-19"><a href="#cb457-19" aria-hidden="true" tabindex="-1"></a>  | Le_step q&#39; -&gt; Le_step (leq_trans p q&#39;)</span>
-<span id="cb457-20"><a href="#cb457-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb457-21"><a href="#cb457-21" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: 0 &lt;= 2 *)</span></span>
-<span id="cb457-22"><a href="#cb457-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> _zero_le_two : (zero, zero <span class="dt">succ</span> <span class="dt">succ</span>) leq =</span>
-<span id="cb457-23"><a href="#cb457-23" aria-hidden="true" tabindex="-1"></a>  Le_step (Le_step Le_refl)</span></code></pre></div>
+<div class="sourceCode" id="cb469"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb469-1"><a href="#cb469-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The poset (int, &lt;=) as a category: *)</span></span>
+<span id="cb469-2"><a href="#cb469-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Objects: integers *)</span></span>
+<span id="cb469-3"><a href="#cb469-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Morphisms: a single &quot;witness&quot; when a &lt;= b *)</span></span>
+<span id="cb469-4"><a href="#cb469-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Composition: transitivity of &lt;= *)</span></span>
+<span id="cb469-5"><a href="#cb469-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb469-6"><a href="#cb469-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* We encode natural numbers as Peano types at the type level: *)</span></span>
+<span id="cb469-7"><a href="#cb469-7" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> zero = Zero</span>
+<span id="cb469-8"><a href="#cb469-8" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;n <span class="dt">succ</span> = Succ</span>
+<span id="cb469-9"><a href="#cb469-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb469-10"><a href="#cb469-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* A witness that n &lt;= m: *)</span></span>
+<span id="cb469-11"><a href="#cb469-11" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (_, _) leq =</span>
+<span id="cb469-12"><a href="#cb469-12" aria-hidden="true" tabindex="-1"></a>  | Le_refl : (&#39;n, &#39;n) leq                       <span class="co">(* n &lt;= n *)</span></span>
+<span id="cb469-13"><a href="#cb469-13" aria-hidden="true" tabindex="-1"></a>  | Le_step : (&#39;n, &#39;m) leq -&gt; (&#39;n, &#39;m <span class="dt">succ</span>) leq  <span class="co">(* n &lt;= m implies n &lt;= m+1 *)</span></span>
+<span id="cb469-14"><a href="#cb469-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb469-15"><a href="#cb469-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Composition = transitivity: if a &lt;= b and b &lt;= c then a &lt;= c *)</span></span>
+<span id="cb469-16"><a href="#cb469-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> leq_trans : <span class="kw">type</span> a b c. (a, b) leq -&gt; (b, c) leq -&gt; (a, c) leq =</span>
+<span id="cb469-17"><a href="#cb469-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> p q -&gt; <span class="kw">match</span> q <span class="kw">with</span></span>
+<span id="cb469-18"><a href="#cb469-18" aria-hidden="true" tabindex="-1"></a>  | Le_refl -&gt; p</span>
+<span id="cb469-19"><a href="#cb469-19" aria-hidden="true" tabindex="-1"></a>  | Le_step q&#39; -&gt; Le_step (leq_trans p q&#39;)</span>
+<span id="cb469-20"><a href="#cb469-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb469-21"><a href="#cb469-21" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: 0 &lt;= 2 *)</span></span>
+<span id="cb469-22"><a href="#cb469-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> _zero_le_two : (zero, zero <span class="dt">succ</span> <span class="dt">succ</span>) leq =</span>
+<span id="cb469-23"><a href="#cb469-23" aria-hidden="true" tabindex="-1"></a>  Le_step (Le_step Le_refl)</span></code></pre></div>
 <p>In general, a poset category has <em>at most one morphism</em>
 between any two objects. Composition is transitivity, identity is
 reflexivity. This is the simplest non-trivial kind of category.</p>
@@ -15850,45 +16116,45 @@ composition is the monoid operation <span
 class="math inline">\cdot</span>, and identity is <span
 class="math inline">e</span>. The monoid laws are exactly the category
 laws:</p>
-<div class="sourceCode" id="cb458"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb458-1"><a href="#cb458-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> MONOID = <span class="kw">sig</span></span>
-<span id="cb458-2"><a href="#cb458-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t</span>
-<span id="cb458-3"><a href="#cb458-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> empty : t                <span class="co">(* identity morphism *)</span></span>
-<span id="cb458-4"><a href="#cb458-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> append : t -&gt; t -&gt; t     <span class="co">(* composition *)</span></span>
-<span id="cb458-5"><a href="#cb458-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb458-6"><a href="#cb458-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb458-7"><a href="#cb458-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* String monoid = one-object category *)</span></span>
-<span id="cb458-8"><a href="#cb458-8" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> StringMonoid : MONOID <span class="kw">with</span> <span class="kw">type</span> t = <span class="dt">string</span> = <span class="kw">struct</span></span>
-<span id="cb458-9"><a href="#cb458-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = <span class="dt">string</span></span>
-<span id="cb458-10"><a href="#cb458-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = <span class="st">&quot;&quot;</span></span>
-<span id="cb458-11"><a href="#cb458-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( ^ )</span>
-<span id="cb458-12"><a href="#cb458-12" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb458-13"><a href="#cb458-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb458-14"><a href="#cb458-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* List monoid = one-object category *)</span></span>
-<span id="cb458-15"><a href="#cb458-15" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ListMonoid (A : <span class="kw">sig</span> <span class="kw">type</span> t <span class="kw">end</span>) : MONOID <span class="kw">with</span> <span class="kw">type</span> t = A.t <span class="dt">list</span> = <span class="kw">struct</span></span>
-<span id="cb458-16"><a href="#cb458-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = A.t <span class="dt">list</span></span>
-<span id="cb458-17"><a href="#cb458-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = []</span>
-<span id="cb458-18"><a href="#cb458-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( @ )</span>
-<span id="cb458-19"><a href="#cb458-19" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<div class="sourceCode" id="cb470"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb470-1"><a href="#cb470-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> MONOID = <span class="kw">sig</span></span>
+<span id="cb470-2"><a href="#cb470-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t</span>
+<span id="cb470-3"><a href="#cb470-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> empty : t                <span class="co">(* identity morphism *)</span></span>
+<span id="cb470-4"><a href="#cb470-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> append : t -&gt; t -&gt; t     <span class="co">(* composition *)</span></span>
+<span id="cb470-5"><a href="#cb470-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb470-6"><a href="#cb470-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb470-7"><a href="#cb470-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* String monoid = one-object category *)</span></span>
+<span id="cb470-8"><a href="#cb470-8" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> StringMonoid : MONOID <span class="kw">with</span> <span class="kw">type</span> t = <span class="dt">string</span> = <span class="kw">struct</span></span>
+<span id="cb470-9"><a href="#cb470-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = <span class="dt">string</span></span>
+<span id="cb470-10"><a href="#cb470-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = <span class="st">&quot;&quot;</span></span>
+<span id="cb470-11"><a href="#cb470-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( ^ )</span>
+<span id="cb470-12"><a href="#cb470-12" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb470-13"><a href="#cb470-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb470-14"><a href="#cb470-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* List monoid = one-object category *)</span></span>
+<span id="cb470-15"><a href="#cb470-15" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ListMonoid (A : <span class="kw">sig</span> <span class="kw">type</span> t <span class="kw">end</span>) : MONOID <span class="kw">with</span> <span class="kw">type</span> t = A.t <span class="dt">list</span> = <span class="kw">struct</span></span>
+<span id="cb470-16"><a href="#cb470-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = A.t <span class="dt">list</span></span>
+<span id="cb470-17"><a href="#cb470-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = []</span>
+<span id="cb470-18"><a href="#cb470-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( @ )</span>
+<span id="cb470-19"><a href="#cb470-19" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <h3 id="the-category-module-type">The Category Module Type</h3>
 <p>We can encode the notion of a category as an OCaml module
 signature:</p>
-<div class="sourceCode" id="cb459"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb459-1"><a href="#cb459-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> CATEGORY = <span class="kw">sig</span></span>
-<span id="cb459-2"><a href="#cb459-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom           <span class="co">(* morphisms from &#39;a to &#39;b *)</span></span>
-<span id="cb459-3"><a href="#cb459-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> id : (&#39;a, &#39;a) hom</span>
-<span id="cb459-4"><a href="#cb459-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> compose : (&#39;b, &#39;c) hom -&gt; (&#39;a, &#39;b) hom -&gt; (&#39;a, &#39;c) hom</span>
-<span id="cb459-5"><a href="#cb459-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<div class="sourceCode" id="cb471"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb471-1"><a href="#cb471-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> CATEGORY = <span class="kw">sig</span></span>
+<span id="cb471-2"><a href="#cb471-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom           <span class="co">(* morphisms from &#39;a to &#39;b *)</span></span>
+<span id="cb471-3"><a href="#cb471-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> id : (&#39;a, &#39;a) hom</span>
+<span id="cb471-4"><a href="#cb471-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> compose : (&#39;b, &#39;c) hom -&gt; (&#39;a, &#39;b) hom -&gt; (&#39;a, &#39;c) hom</span>
+<span id="cb471-5"><a href="#cb471-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <p>The type parameters <code>'a</code> and <code>'b</code> are phantom
 types – they track the source and target of morphisms at the type level,
 ensuring only composable morphisms can be composed. OCaml functions form
 the most basic instance:</p>
-<div class="sourceCode" id="cb460"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb460-1"><a href="#cb460-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FunCat : CATEGORY <span class="kw">with</span> <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b = <span class="kw">struct</span></span>
-<span id="cb460-2"><a href="#cb460-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b</span>
-<span id="cb460-3"><a href="#cb460-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> id x = x</span>
-<span id="cb460-4"><a href="#cb460-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> compose f g x = f (g x)</span>
-<span id="cb460-5"><a href="#cb460-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<div class="sourceCode" id="cb472"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb472-1"><a href="#cb472-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FunCat : CATEGORY <span class="kw">with</span> <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b = <span class="kw">struct</span></span>
+<span id="cb472-2"><a href="#cb472-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b</span>
+<span id="cb472-3"><a href="#cb472-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> id x = x</span>
+<span id="cb472-4"><a href="#cb472-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> compose f g x = f (g x)</span>
+<span id="cb472-5"><a href="#cb472-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <h2 id="revisiting-the-book-through-a-categorical-lens">12.2 Revisiting
 the Book Through a Categorical Lens</h2>
 <p>Before introducing new material, let us look back at what the
@@ -15993,20 +16259,20 @@ category: there exist morphisms <span class="math inline">f : A \to
 B</span> and <span class="math inline">g : B \to A</span> such that
 <span class="math inline">g \circ f = \text{id}_A</span> and <span
 class="math inline">f \circ g = \text{id}_B</span>.</p>
-<div class="sourceCode" id="cb461"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb461-1"><a href="#cb461-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Type isomorphism from Chapter 2, restated categorically: *)</span></span>
-<span id="cb461-2"><a href="#cb461-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* swap_pair and swap_pair are inverse morphisms in FunCat. *)</span></span>
-<span id="cb461-3"><a href="#cb461-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> swap_pair (a, b) = (b, a)</span>
-<span id="cb461-4"><a href="#cb461-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose swap_pair swap_pair (<span class="dv">1</span>, <span class="st">&quot;hello&quot;</span>) = (<span class="dv">1</span>, <span class="st">&quot;hello&quot;</span>))</span>
-<span id="cb461-5"><a href="#cb461-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* swap ∘ swap = id: the round-trip is the identity morphism. *)</span></span>
-<span id="cb461-6"><a href="#cb461-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb461-7"><a href="#cb461-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* Distributivity: A * (B + C) ≅ A * B + A * C *)</span></span>
-<span id="cb461-8"><a href="#cb461-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dist : &#39;a * (&#39;b, &#39;c) <span class="dt">result</span> -&gt; ((&#39;a * &#39;b), (&#39;a * &#39;c)) <span class="dt">result</span> =</span>
-<span id="cb461-9"><a href="#cb461-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">function</span> (a, <span class="dt">Ok</span> b) -&gt; <span class="dt">Ok</span> (a, b) | (a, <span class="dt">Error</span> c) -&gt; <span class="dt">Error</span> (a, c)</span>
-<span id="cb461-10"><a href="#cb461-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> undist : ((&#39;a * &#39;b), (&#39;a * &#39;c)) <span class="dt">result</span> -&gt; &#39;a * (&#39;b, &#39;c) <span class="dt">result</span> =</span>
-<span id="cb461-11"><a href="#cb461-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">function</span> <span class="dt">Ok</span> (a, b) -&gt; (a, <span class="dt">Ok</span> b) | <span class="dt">Error</span> (a, c) -&gt; (a, <span class="dt">Error</span> c)</span>
-<span id="cb461-12"><a href="#cb461-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (undist (dist (<span class="dv">1</span>, <span class="dt">Ok</span> <span class="st">&quot;yes&quot;</span>)) = (<span class="dv">1</span>, <span class="dt">Ok</span> <span class="st">&quot;yes&quot;</span>))</span>
-<span id="cb461-13"><a href="#cb461-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (undist (dist (<span class="dv">1</span>, <span class="dt">Error</span> <span class="fl">2.0</span>)) = (<span class="dv">1</span>, <span class="dt">Error</span> <span class="fl">2.0</span>))</span></code></pre></div>
+<div class="sourceCode" id="cb473"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb473-1"><a href="#cb473-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Type isomorphism from Chapter 2, restated categorically: *)</span></span>
+<span id="cb473-2"><a href="#cb473-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* swap_pair and swap_pair are inverse morphisms in FunCat. *)</span></span>
+<span id="cb473-3"><a href="#cb473-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> swap_pair (a, b) = (b, a)</span>
+<span id="cb473-4"><a href="#cb473-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (compose swap_pair swap_pair (<span class="dv">1</span>, <span class="st">&quot;hello&quot;</span>) = (<span class="dv">1</span>, <span class="st">&quot;hello&quot;</span>))</span>
+<span id="cb473-5"><a href="#cb473-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* swap ∘ swap = id: the round-trip is the identity morphism. *)</span></span>
+<span id="cb473-6"><a href="#cb473-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb473-7"><a href="#cb473-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* Distributivity: A * (B + C) ≅ A * B + A * C *)</span></span>
+<span id="cb473-8"><a href="#cb473-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dist : &#39;a * (&#39;b, &#39;c) <span class="dt">result</span> -&gt; ((&#39;a * &#39;b), (&#39;a * &#39;c)) <span class="dt">result</span> =</span>
+<span id="cb473-9"><a href="#cb473-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">function</span> (a, <span class="dt">Ok</span> b) -&gt; <span class="dt">Ok</span> (a, b) | (a, <span class="dt">Error</span> c) -&gt; <span class="dt">Error</span> (a, c)</span>
+<span id="cb473-10"><a href="#cb473-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> undist : ((&#39;a * &#39;b), (&#39;a * &#39;c)) <span class="dt">result</span> -&gt; &#39;a * (&#39;b, &#39;c) <span class="dt">result</span> =</span>
+<span id="cb473-11"><a href="#cb473-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">function</span> <span class="dt">Ok</span> (a, b) -&gt; (a, <span class="dt">Ok</span> b) | <span class="dt">Error</span> (a, c) -&gt; (a, <span class="dt">Error</span> c)</span>
+<span id="cb473-12"><a href="#cb473-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (undist (dist (<span class="dv">1</span>, <span class="dt">Ok</span> <span class="st">&quot;yes&quot;</span>)) = (<span class="dv">1</span>, <span class="dt">Ok</span> <span class="st">&quot;yes&quot;</span>))</span>
+<span id="cb473-13"><a href="#cb473-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (undist (dist (<span class="dv">1</span>, <span class="dt">Error</span> <span class="fl">2.0</span>)) = (<span class="dv">1</span>, <span class="dt">Error</span> <span class="fl">2.0</span>))</span></code></pre></div>
 <p><strong><code>map</code> is a functor action.</strong> In Chapter 6,
 we wrote <code>List.map f</code> to transform every element of a list.
 The function <code>List.map</code> sends each morphism <span
@@ -16030,23 +16296,23 @@ replacing <code>(::)</code> with a function and <code>[]</code> with a
 value. This is the <em>catamorphism</em> (or <em>algebra morphism</em>)
 for the list functor – the unique morphism from the initial algebra to
 any other algebra.</p>
-<div class="sourceCode" id="cb462"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb462-1"><a href="#cb462-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* An &quot;algebra&quot; for the list functor is a pair (op, z): *)</span></span>
-<span id="cb462-2"><a href="#cb462-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* op replaces (::) and z replaces [].                  *)</span></span>
-<span id="cb462-3"><a href="#cb462-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* The catamorphism folds any list using the algebra.   *)</span></span>
-<span id="cb462-4"><a href="#cb462-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> cata op z xs = <span class="dt">List</span>.fold_right op xs z</span>
-<span id="cb462-5"><a href="#cb462-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb462-6"><a href="#cb462-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* length = catamorphism with algebra (fun _ n -&gt; n+1, 0): *)</span></span>
-<span id="cb462-7"><a href="#cb462-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> len xs = cata (<span class="kw">fun</span> _ n -&gt; n + <span class="dv">1</span>) <span class="dv">0</span> xs</span>
-<span id="cb462-8"><a href="#cb462-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (len [<span class="dv">10</span>; <span class="dv">20</span>; <span class="dv">30</span>] = <span class="dv">3</span>)</span>
-<span id="cb462-9"><a href="#cb462-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb462-10"><a href="#cb462-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* sum = catamorphism with algebra ((+), 0): *)</span></span>
-<span id="cb462-11"><a href="#cb462-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> sum xs = cata ( + ) <span class="dv">0</span> xs</span>
-<span id="cb462-12"><a href="#cb462-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (sum [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>; <span class="dv">4</span>] = <span class="dv">10</span>)</span>
-<span id="cb462-13"><a href="#cb462-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb462-14"><a href="#cb462-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* map f = catamorphism with algebra ((fun x acc -&gt; f x :: acc), []): *)</span></span>
-<span id="cb462-15"><a href="#cb462-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> map_via_cata f xs = cata (<span class="kw">fun</span> x acc -&gt; f x :: acc) [] xs</span>
-<span id="cb462-16"><a href="#cb462-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (map_via_cata (<span class="kw">fun</span> x -&gt; x * <span class="dv">10</span>) [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>] = [<span class="dv">10</span>; <span class="dv">20</span>; <span class="dv">30</span>])</span></code></pre></div>
+<div class="sourceCode" id="cb474"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb474-1"><a href="#cb474-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* An &quot;algebra&quot; for the list functor is a pair (op, z): *)</span></span>
+<span id="cb474-2"><a href="#cb474-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* op replaces (::) and z replaces [].                  *)</span></span>
+<span id="cb474-3"><a href="#cb474-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* The catamorphism folds any list using the algebra.   *)</span></span>
+<span id="cb474-4"><a href="#cb474-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> cata op z xs = <span class="dt">List</span>.fold_right op xs z</span>
+<span id="cb474-5"><a href="#cb474-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb474-6"><a href="#cb474-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* length = catamorphism with algebra (fun _ n -&gt; n+1, 0): *)</span></span>
+<span id="cb474-7"><a href="#cb474-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> len xs = cata (<span class="kw">fun</span> _ n -&gt; n + <span class="dv">1</span>) <span class="dv">0</span> xs</span>
+<span id="cb474-8"><a href="#cb474-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (len [<span class="dv">10</span>; <span class="dv">20</span>; <span class="dv">30</span>] = <span class="dv">3</span>)</span>
+<span id="cb474-9"><a href="#cb474-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb474-10"><a href="#cb474-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* sum = catamorphism with algebra ((+), 0): *)</span></span>
+<span id="cb474-11"><a href="#cb474-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> sum xs = cata ( + ) <span class="dv">0</span> xs</span>
+<span id="cb474-12"><a href="#cb474-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (sum [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>; <span class="dv">4</span>] = <span class="dv">10</span>)</span>
+<span id="cb474-13"><a href="#cb474-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb474-14"><a href="#cb474-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* map f = catamorphism with algebra ((fun x acc -&gt; f x :: acc), []): *)</span></span>
+<span id="cb474-15"><a href="#cb474-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> map_via_cata f xs = cata (<span class="kw">fun</span> x acc -&gt; f x :: acc) [] xs</span>
+<span id="cb474-16"><a href="#cb474-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (map_via_cata (<span class="kw">fun</span> x -&gt; x * <span class="dv">10</span>) [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>] = [<span class="dv">10</span>; <span class="dv">20</span>; <span class="dv">30</span>])</span></code></pre></div>
 <h2 id="typed-morphisms-with-gadts">12.3 Typed Morphisms with GADTs</h2>
 <p>Chapter 9 introduced GADTs. Now we use them to enforce categorical
 structure at the type level. The key idea: a
@@ -16059,39 +16325,39 @@ Graph</h3>
 source and target. The <strong>free category</strong> on this graph is
 the category whose morphisms are all paths through the graph. GADTs let
 us express this directly:</p>
-<div class="sourceCode" id="cb463"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb463-1"><a href="#cb463-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A typed graph of &quot;pipeline stages&quot; *)</span></span>
-<span id="cb463-2"><a href="#cb463-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;a, &#39;b) stage =</span>
-<span id="cb463-3"><a href="#cb463-3" aria-hidden="true" tabindex="-1"></a>  | Parse   : (<span class="dt">string</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
-<span id="cb463-4"><a href="#cb463-4" aria-hidden="true" tabindex="-1"></a>  | Filter  : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
-<span id="cb463-5"><a href="#cb463-5" aria-hidden="true" tabindex="-1"></a>  | Count   : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">int</span>) stage</span>
-<span id="cb463-6"><a href="#cb463-6" aria-hidden="true" tabindex="-1"></a>  | Show    : (<span class="dt">int</span>, <span class="dt">string</span>) stage</span>
-<span id="cb463-7"><a href="#cb463-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb463-8"><a href="#cb463-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* The free category: typed paths through the graph *)</span></span>
-<span id="cb463-9"><a href="#cb463-9" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;a, &#39;b) path =</span>
-<span id="cb463-10"><a href="#cb463-10" aria-hidden="true" tabindex="-1"></a>  | Nil  : (&#39;a, &#39;a) path</span>
-<span id="cb463-11"><a href="#cb463-11" aria-hidden="true" tabindex="-1"></a>  | Cons : (&#39;a, &#39;b) stage * (&#39;b, &#39;c) path -&gt; (&#39;a, &#39;c) path</span></code></pre></div>
+<div class="sourceCode" id="cb475"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb475-1"><a href="#cb475-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A typed graph of &quot;pipeline stages&quot; *)</span></span>
+<span id="cb475-2"><a href="#cb475-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;a, &#39;b) stage =</span>
+<span id="cb475-3"><a href="#cb475-3" aria-hidden="true" tabindex="-1"></a>  | Parse   : (<span class="dt">string</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
+<span id="cb475-4"><a href="#cb475-4" aria-hidden="true" tabindex="-1"></a>  | Filter  : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
+<span id="cb475-5"><a href="#cb475-5" aria-hidden="true" tabindex="-1"></a>  | Count   : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">int</span>) stage</span>
+<span id="cb475-6"><a href="#cb475-6" aria-hidden="true" tabindex="-1"></a>  | Show    : (<span class="dt">int</span>, <span class="dt">string</span>) stage</span>
+<span id="cb475-7"><a href="#cb475-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb475-8"><a href="#cb475-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* The free category: typed paths through the graph *)</span></span>
+<span id="cb475-9"><a href="#cb475-9" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;a, &#39;b) path =</span>
+<span id="cb475-10"><a href="#cb475-10" aria-hidden="true" tabindex="-1"></a>  | Nil  : (&#39;a, &#39;a) path</span>
+<span id="cb475-11"><a href="#cb475-11" aria-hidden="true" tabindex="-1"></a>  | Cons : (&#39;a, &#39;b) stage * (&#39;b, &#39;c) path -&gt; (&#39;a, &#39;c) path</span></code></pre></div>
 <p>The type <code>('a, 'b) path</code> enforces that paths are
 composable: each edge’s target must match the next edge’s source. The
 type checker rejects ill-formed pipelines at compile time:</p>
-<div class="sourceCode" id="cb464"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb464-1"><a href="#cb464-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A valid pipeline: string -&gt; string list -&gt; int -&gt; string *)</span></span>
-<span id="cb464-2"><a href="#cb464-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> my_pipeline : (<span class="dt">string</span>, <span class="dt">string</span>) path =</span>
-<span id="cb464-3"><a href="#cb464-3" aria-hidden="true" tabindex="-1"></a>  Cons (Parse, Cons (Count, Cons (Show, Nil)))</span></code></pre></div>
-<div class="sourceCode" id="cb465"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb465-1"><a href="#cb465-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* This would NOT compile -- types don&#39;t match: *)</span></span>
-<span id="cb465-2"><a href="#cb465-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Cons (Parse, Cons (Show, Nil)) *)</span></span>
-<span id="cb465-3"><a href="#cb465-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* Error: string list ≠ int *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb476"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb476-1"><a href="#cb476-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A valid pipeline: string -&gt; string list -&gt; int -&gt; string *)</span></span>
+<span id="cb476-2"><a href="#cb476-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> my_pipeline : (<span class="dt">string</span>, <span class="dt">string</span>) path =</span>
+<span id="cb476-3"><a href="#cb476-3" aria-hidden="true" tabindex="-1"></a>  Cons (Parse, Cons (Count, Cons (Show, Nil)))</span></code></pre></div>
+<div class="sourceCode" id="cb477"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb477-1"><a href="#cb477-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* This would NOT compile -- types don&#39;t match: *)</span></span>
+<span id="cb477-2"><a href="#cb477-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Cons (Parse, Cons (Show, Nil)) *)</span></span>
+<span id="cb477-3"><a href="#cb477-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* Error: string list ≠ int *)</span></span></code></pre></div>
 <p>Without GADTs, we could build ill-formed pipelines that compile –
 with GADTs, the composability invariant is enforced statically.</p>
 <h3 id="composing-paths">Composing Paths</h3>
 <p>Composition of paths is concatenation, which we can define by
 recursion on the first path:</p>
-<div class="sourceCode" id="cb466"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb466-1"><a href="#cb466-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> concat : <span class="kw">type</span> a b c. (a, b) path -&gt; (b, c) path -&gt; (a, c) path =</span>
-<span id="cb466-2"><a href="#cb466-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> p q -&gt; <span class="kw">match</span> p <span class="kw">with</span></span>
-<span id="cb466-3"><a href="#cb466-3" aria-hidden="true" tabindex="-1"></a>  | Nil -&gt; q</span>
-<span id="cb466-4"><a href="#cb466-4" aria-hidden="true" tabindex="-1"></a>  | Cons (edge, rest) -&gt; Cons (edge, concat rest q)</span></code></pre></div>
+<div class="sourceCode" id="cb478"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb478-1"><a href="#cb478-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> concat : <span class="kw">type</span> a b c. (a, b) path -&gt; (b, c) path -&gt; (a, c) path =</span>
+<span id="cb478-2"><a href="#cb478-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> p q -&gt; <span class="kw">match</span> p <span class="kw">with</span></span>
+<span id="cb478-3"><a href="#cb478-3" aria-hidden="true" tabindex="-1"></a>  | Nil -&gt; q</span>
+<span id="cb478-4"><a href="#cb478-4" aria-hidden="true" tabindex="-1"></a>  | Cons (edge, rest) -&gt; Cons (edge, concat rest q)</span></code></pre></div>
 <p>This is a category: <code>Nil</code> is the identity,
 <code>concat</code> is composition, and associativity follows from the
 recursive definition.</p>
@@ -16099,39 +16365,39 @@ recursive definition.</p>
 <p>The power of this encoding is that we can <em>interpret</em> a typed
 path into actual functions. Each stage maps to a concrete
 computation:</p>
-<div class="sourceCode" id="cb467"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb467-1"><a href="#cb467-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> interpret_stage : <span class="kw">type</span> a b. (a, b) stage -&gt; a -&gt; b = <span class="kw">function</span></span>
-<span id="cb467-2"><a href="#cb467-2" aria-hidden="true" tabindex="-1"></a>  | Parse  -&gt; <span class="dt">String</span>.split_on_char <span class="ch">&#39; &#39;</span></span>
-<span id="cb467-3"><a href="#cb467-3" aria-hidden="true" tabindex="-1"></a>  | Filter -&gt; <span class="dt">List</span>.filter (<span class="kw">fun</span> s -&gt; <span class="dt">String</span>.length s &gt; <span class="dv">2</span>)</span>
-<span id="cb467-4"><a href="#cb467-4" aria-hidden="true" tabindex="-1"></a>  | Count  -&gt; <span class="dt">List</span>.length</span>
-<span id="cb467-5"><a href="#cb467-5" aria-hidden="true" tabindex="-1"></a>  | Show   -&gt; <span class="dt">string_of_int</span></span>
-<span id="cb467-6"><a href="#cb467-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb467-7"><a href="#cb467-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> interpret : <span class="kw">type</span> a b. (a, b) path -&gt; a -&gt; b = <span class="kw">function</span></span>
-<span id="cb467-8"><a href="#cb467-8" aria-hidden="true" tabindex="-1"></a>  | Nil -&gt; <span class="dt">Fun</span>.id</span>
-<span id="cb467-9"><a href="#cb467-9" aria-hidden="true" tabindex="-1"></a>  | Cons (stage, rest) -&gt; <span class="kw">fun</span> x -&gt; interpret rest (interpret_stage stage x)</span>
-<span id="cb467-10"><a href="#cb467-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb467-11"><a href="#cb467-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (interpret my_pipeline <span class="st">&quot;the quick brown fox&quot;</span> = <span class="st">&quot;4&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb479"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb479-1"><a href="#cb479-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> interpret_stage : <span class="kw">type</span> a b. (a, b) stage -&gt; a -&gt; b = <span class="kw">function</span></span>
+<span id="cb479-2"><a href="#cb479-2" aria-hidden="true" tabindex="-1"></a>  | Parse  -&gt; <span class="dt">String</span>.split_on_char <span class="ch">&#39; &#39;</span></span>
+<span id="cb479-3"><a href="#cb479-3" aria-hidden="true" tabindex="-1"></a>  | Filter -&gt; <span class="dt">List</span>.filter (<span class="kw">fun</span> s -&gt; <span class="dt">String</span>.length s &gt; <span class="dv">2</span>)</span>
+<span id="cb479-4"><a href="#cb479-4" aria-hidden="true" tabindex="-1"></a>  | Count  -&gt; <span class="dt">List</span>.length</span>
+<span id="cb479-5"><a href="#cb479-5" aria-hidden="true" tabindex="-1"></a>  | Show   -&gt; <span class="dt">string_of_int</span></span>
+<span id="cb479-6"><a href="#cb479-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb479-7"><a href="#cb479-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> interpret : <span class="kw">type</span> a b. (a, b) path -&gt; a -&gt; b = <span class="kw">function</span></span>
+<span id="cb479-8"><a href="#cb479-8" aria-hidden="true" tabindex="-1"></a>  | Nil -&gt; <span class="dt">Fun</span>.id</span>
+<span id="cb479-9"><a href="#cb479-9" aria-hidden="true" tabindex="-1"></a>  | Cons (stage, rest) -&gt; <span class="kw">fun</span> x -&gt; interpret rest (interpret_stage stage x)</span>
+<span id="cb479-10"><a href="#cb479-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb479-11"><a href="#cb479-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (interpret my_pipeline <span class="st">&quot;the quick brown fox&quot;</span> = <span class="st">&quot;4&quot;</span>)</span></code></pre></div>
 <h3 id="type-witnesses-as-reification">Type Witnesses as
 Reification</h3>
 <p>GADTs also let us <em>reify</em> types as values – a
 <code>'a ty</code> GADT represents the type <code>'a</code> as a
 first-class value:</p>
-<div class="sourceCode" id="cb468"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb468-1"><a href="#cb468-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> _ ty =</span>
-<span id="cb468-2"><a href="#cb468-2" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Int</span>    : <span class="dt">int</span> ty</span>
-<span id="cb468-3"><a href="#cb468-3" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">String</span> : <span class="dt">string</span> ty</span>
-<span id="cb468-4"><a href="#cb468-4" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Bool</span>   : <span class="dt">bool</span> ty</span>
-<span id="cb468-5"><a href="#cb468-5" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">List</span>   : &#39;a ty -&gt; &#39;a <span class="dt">list</span> ty</span>
-<span id="cb468-6"><a href="#cb468-6" aria-hidden="true" tabindex="-1"></a>  | Pair   : &#39;a ty * &#39;b ty -&gt; (&#39;a * &#39;b) ty</span>
-<span id="cb468-7"><a href="#cb468-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb468-8"><a href="#cb468-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> show_ty : <span class="kw">type</span> a. a ty -&gt; <span class="dt">string</span> = <span class="kw">function</span></span>
-<span id="cb468-9"><a href="#cb468-9" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Int</span> -&gt; <span class="st">&quot;int&quot;</span></span>
-<span id="cb468-10"><a href="#cb468-10" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">String</span> -&gt; <span class="st">&quot;string&quot;</span></span>
-<span id="cb468-11"><a href="#cb468-11" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Bool</span> -&gt; <span class="st">&quot;bool&quot;</span></span>
-<span id="cb468-12"><a href="#cb468-12" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">List</span> t -&gt; show_ty t ^ <span class="st">&quot; list&quot;</span></span>
-<span id="cb468-13"><a href="#cb468-13" aria-hidden="true" tabindex="-1"></a>  | Pair (a, b) -&gt; <span class="st">&quot;(&quot;</span> ^ show_ty a ^ <span class="st">&quot; * &quot;</span> ^ show_ty b ^ <span class="st">&quot;)&quot;</span></span>
-<span id="cb468-14"><a href="#cb468-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb468-15"><a href="#cb468-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (show_ty (<span class="dt">List</span> (Pair (<span class="dt">Int</span>, <span class="dt">Bool</span>))) = <span class="st">&quot;(int * bool) list&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb480"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb480-1"><a href="#cb480-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> _ ty =</span>
+<span id="cb480-2"><a href="#cb480-2" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Int</span>    : <span class="dt">int</span> ty</span>
+<span id="cb480-3"><a href="#cb480-3" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">String</span> : <span class="dt">string</span> ty</span>
+<span id="cb480-4"><a href="#cb480-4" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Bool</span>   : <span class="dt">bool</span> ty</span>
+<span id="cb480-5"><a href="#cb480-5" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">List</span>   : &#39;a ty -&gt; &#39;a <span class="dt">list</span> ty</span>
+<span id="cb480-6"><a href="#cb480-6" aria-hidden="true" tabindex="-1"></a>  | Pair   : &#39;a ty * &#39;b ty -&gt; (&#39;a * &#39;b) ty</span>
+<span id="cb480-7"><a href="#cb480-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb480-8"><a href="#cb480-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> show_ty : <span class="kw">type</span> a. a ty -&gt; <span class="dt">string</span> = <span class="kw">function</span></span>
+<span id="cb480-9"><a href="#cb480-9" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Int</span> -&gt; <span class="st">&quot;int&quot;</span></span>
+<span id="cb480-10"><a href="#cb480-10" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">String</span> -&gt; <span class="st">&quot;string&quot;</span></span>
+<span id="cb480-11"><a href="#cb480-11" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Bool</span> -&gt; <span class="st">&quot;bool&quot;</span></span>
+<span id="cb480-12"><a href="#cb480-12" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">List</span> t -&gt; show_ty t ^ <span class="st">&quot; list&quot;</span></span>
+<span id="cb480-13"><a href="#cb480-13" aria-hidden="true" tabindex="-1"></a>  | Pair (a, b) -&gt; <span class="st">&quot;(&quot;</span> ^ show_ty a ^ <span class="st">&quot; * &quot;</span> ^ show_ty b ^ <span class="st">&quot;)&quot;</span></span>
+<span id="cb480-14"><a href="#cb480-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb480-15"><a href="#cb480-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (show_ty (<span class="dt">List</span> (Pair (<span class="dt">Int</span>, <span class="dt">Bool</span>))) = <span class="st">&quot;(int * bool) list&quot;</span>)</span></code></pre></div>
 <p>This reification is OCaml’s version of the <em>Yoneda embedding</em>
 for types: each type is represented by a value that “remembers” what it
 is, enabling type-safe operations that depend on runtime type
@@ -16145,11 +16411,11 @@ OCaml. Let us untangle them.</p>
 <p>OCaml’s module system has <em>functors</em>: functions from modules
 to modules. We used <code>Map.Make</code> in Chapter 5 to create
 specialized map modules:</p>
-<div class="sourceCode" id="cb469"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb469-1"><a href="#cb469-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> StringMap = <span class="dt">Map</span>.Make(<span class="dt">String</span>)</span>
-<span id="cb469-2"><a href="#cb469-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Map.Make is an OCaml (module) functor: *)</span></span>
-<span id="cb469-3"><a href="#cb469-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* it takes a module with type t and compare, *)</span></span>
-<span id="cb469-4"><a href="#cb469-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* and returns a module with map operations *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb481"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb481-1"><a href="#cb481-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> StringMap = <span class="dt">Map</span>.Make(<span class="dt">String</span>)</span>
+<span id="cb481-2"><a href="#cb481-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Map.Make is an OCaml (module) functor: *)</span></span>
+<span id="cb481-3"><a href="#cb481-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* it takes a module with type t and compare, *)</span></span>
+<span id="cb481-4"><a href="#cb481-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* and returns a module with map operations *)</span></span></code></pre></div>
 <p>These are not categorical functors in general – they do not
 necessarily preserve composition. They are closer to parameterized
 modules. However, the <em>name</em> comes from category theory, and in
@@ -16160,87 +16426,87 @@ Class Pattern</h3>
 <p>The categorical notion of a functor is an endofunctor on the category
 of types. In OCaml, we encode it as a module signature requiring a
 <code>map</code> function that preserves identity and composition:</p>
-<div class="sourceCode" id="cb470"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb470-1"><a href="#cb470-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> FUNCTOR = <span class="kw">sig</span></span>
-<span id="cb470-2"><a href="#cb470-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t</span>
-<span id="cb470-3"><a href="#cb470-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> map : (&#39;a -&gt; &#39;b) -&gt; &#39;a t -&gt; &#39;b t</span>
-<span id="cb470-4"><a href="#cb470-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* Laws (not checked by the compiler): *)</span></span>
-<span id="cb470-5"><a href="#cb470-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map id = id *)</span></span>
-<span id="cb470-6"><a href="#cb470-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map (f ∘ g) = map f ∘ map g *)</span></span>
-<span id="cb470-7"><a href="#cb470-7" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<div class="sourceCode" id="cb482"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb482-1"><a href="#cb482-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> FUNCTOR = <span class="kw">sig</span></span>
+<span id="cb482-2"><a href="#cb482-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t</span>
+<span id="cb482-3"><a href="#cb482-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> map : (&#39;a -&gt; &#39;b) -&gt; &#39;a t -&gt; &#39;b t</span>
+<span id="cb482-4"><a href="#cb482-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* Laws (not checked by the compiler): *)</span></span>
+<span id="cb482-5"><a href="#cb482-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map id = id *)</span></span>
+<span id="cb482-6"><a href="#cb482-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map (f ∘ g) = map f ∘ map g *)</span></span>
+<span id="cb482-7"><a href="#cb482-7" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <p>Many standard types are functors:</p>
-<div class="sourceCode" id="cb471"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb471-1"><a href="#cb471-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ListFunctor : FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">list</span> = <span class="kw">struct</span></span>
-<span id="cb471-2"><a href="#cb471-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">list</span></span>
-<span id="cb471-3"><a href="#cb471-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map = <span class="dt">List</span>.map</span>
-<span id="cb471-4"><a href="#cb471-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb471-5"><a href="#cb471-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb471-6"><a href="#cb471-6" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> OptionFunctor : FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">option</span> = <span class="kw">struct</span></span>
-<span id="cb471-7"><a href="#cb471-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">option</span></span>
-<span id="cb471-8"><a href="#cb471-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map = <span class="dt">Option</span>.map</span>
-<span id="cb471-9"><a href="#cb471-9" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb471-10"><a href="#cb471-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb471-11"><a href="#cb471-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* The &quot;reader&quot; functor: (&#39;a -&gt; _) is functorial in the return type *)</span></span>
-<span id="cb471-12"><a href="#cb471-12" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ReaderFunctor (R : <span class="kw">sig</span> <span class="kw">type</span> t <span class="kw">end</span>) :</span>
-<span id="cb471-13"><a href="#cb471-13" aria-hidden="true" tabindex="-1"></a>  FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = R.t -&gt; &#39;a = <span class="kw">struct</span></span>
-<span id="cb471-14"><a href="#cb471-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = R.t -&gt; &#39;a</span>
-<span id="cb471-15"><a href="#cb471-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map f g r = f (g r)    <span class="co">(* = compose f g *)</span></span>
-<span id="cb471-16"><a href="#cb471-16" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<div class="sourceCode" id="cb483"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb483-1"><a href="#cb483-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ListFunctor : FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">list</span> = <span class="kw">struct</span></span>
+<span id="cb483-2"><a href="#cb483-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">list</span></span>
+<span id="cb483-3"><a href="#cb483-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map = <span class="dt">List</span>.map</span>
+<span id="cb483-4"><a href="#cb483-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb483-5"><a href="#cb483-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb483-6"><a href="#cb483-6" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> OptionFunctor : FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">option</span> = <span class="kw">struct</span></span>
+<span id="cb483-7"><a href="#cb483-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a <span class="dt">option</span></span>
+<span id="cb483-8"><a href="#cb483-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map = <span class="dt">Option</span>.map</span>
+<span id="cb483-9"><a href="#cb483-9" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb483-10"><a href="#cb483-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb483-11"><a href="#cb483-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* The &quot;reader&quot; functor: (&#39;a -&gt; _) is functorial in the return type *)</span></span>
+<span id="cb483-12"><a href="#cb483-12" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ReaderFunctor (R : <span class="kw">sig</span> <span class="kw">type</span> t <span class="kw">end</span>) :</span>
+<span id="cb483-13"><a href="#cb483-13" aria-hidden="true" tabindex="-1"></a>  FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = R.t -&gt; &#39;a = <span class="kw">struct</span></span>
+<span id="cb483-14"><a href="#cb483-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = R.t -&gt; &#39;a</span>
+<span id="cb483-15"><a href="#cb483-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map f g r = f (g r)    <span class="co">(* = compose f g *)</span></span>
+<span id="cb483-16"><a href="#cb483-16" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <h3 id="view-3-gadt-encoded-typed-functors">View 3: GADT-Encoded Typed
 Functors</h3>
 <p>Between typed categories (Section 12.3), a functor maps objects and
 morphisms while preserving composition and identity. With GADTs, we can
 express this:</p>
-<div class="sourceCode" id="cb472"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb472-1"><a href="#cb472-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> CATEGORY = <span class="kw">sig</span></span>
-<span id="cb472-2"><a href="#cb472-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom</span>
-<span id="cb472-3"><a href="#cb472-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> id : (&#39;a, &#39;a) hom</span>
-<span id="cb472-4"><a href="#cb472-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> compose : (&#39;b, &#39;c) hom -&gt; (&#39;a, &#39;b) hom -&gt; (&#39;a, &#39;c) hom</span>
-<span id="cb472-5"><a href="#cb472-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb472-6"><a href="#cb472-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb472-7"><a href="#cb472-7" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> TYPED_FUNCTOR = <span class="kw">sig</span></span>
-<span id="cb472-8"><a href="#cb472-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Source : CATEGORY</span>
-<span id="cb472-9"><a href="#cb472-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Target : CATEGORY</span>
-<span id="cb472-10"><a href="#cb472-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a obj                  <span class="co">(* object mapping *)</span></span>
-<span id="cb472-11"><a href="#cb472-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> map_hom : (&#39;a, &#39;b) Source.hom -&gt; (&#39;a obj, &#39;b obj) Target.hom</span>
-<span id="cb472-12"><a href="#cb472-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* Laws: *)</span></span>
-<span id="cb472-13"><a href="#cb472-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map_hom id = id *)</span></span>
-<span id="cb472-14"><a href="#cb472-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map_hom (compose f g) = compose (map_hom f) (map_hom g) *)</span></span>
-<span id="cb472-15"><a href="#cb472-15" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
-<div class="sourceCode" id="cb473"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb473-1"><a href="#cb473-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* FunCat: the category of OCaml functions *)</span></span>
-<span id="cb473-2"><a href="#cb473-2" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FunCat : CATEGORY <span class="kw">with</span> <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b = <span class="kw">struct</span></span>
-<span id="cb473-3"><a href="#cb473-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b</span>
-<span id="cb473-4"><a href="#cb473-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> id x = x</span>
-<span id="cb473-5"><a href="#cb473-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> compose f g x = f (g x)</span>
-<span id="cb473-6"><a href="#cb473-6" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb473-7"><a href="#cb473-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb473-8"><a href="#cb473-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* List is a typed functor from FunCat to FunCat: *)</span></span>
-<span id="cb473-9"><a href="#cb473-9" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Object mapping: &#39;a ↦ &#39;a list *)</span></span>
-<span id="cb473-10"><a href="#cb473-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Morphism mapping: (f : &#39;a -&gt; &#39;b) ↦ (List.map f : &#39;a list -&gt; &#39;b list) *)</span></span>
-<span id="cb473-11"><a href="#cb473-11" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ListTypedFunctor : TYPED_FUNCTOR</span>
-<span id="cb473-12"><a href="#cb473-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">with</span> <span class="kw">module</span> Source = FunCat</span>
-<span id="cb473-13"><a href="#cb473-13" aria-hidden="true" tabindex="-1"></a>   <span class="kw">and</span> <span class="kw">module</span> Target = FunCat</span>
-<span id="cb473-14"><a href="#cb473-14" aria-hidden="true" tabindex="-1"></a>   <span class="kw">and</span> <span class="kw">type</span> &#39;a obj = &#39;a <span class="dt">list</span> = <span class="kw">struct</span></span>
-<span id="cb473-15"><a href="#cb473-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Source = FunCat</span>
-<span id="cb473-16"><a href="#cb473-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Target = FunCat</span>
-<span id="cb473-17"><a href="#cb473-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a obj = &#39;a <span class="dt">list</span></span>
-<span id="cb473-18"><a href="#cb473-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map_hom f = <span class="dt">List</span>.map f</span>
-<span id="cb473-19"><a href="#cb473-19" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb473-20"><a href="#cb473-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb473-21"><a href="#cb473-21" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify functor laws: *)</span></span>
-<span id="cb473-22"><a href="#cb473-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x + <span class="dv">1</span></span>
-<span id="cb473-23"><a href="#cb473-23" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = x * <span class="dv">2</span></span>
-<span id="cb473-24"><a href="#cb473-24" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> xs = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>]</span>
-<span id="cb473-25"><a href="#cb473-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb473-26"><a href="#cb473-26" aria-hidden="true" tabindex="-1"></a><span class="co">(* map_hom id = id *)</span></span>
-<span id="cb473-27"><a href="#cb473-27" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (ListTypedFunctor.map_hom FunCat.id xs = FunCat.id xs)</span>
-<span id="cb473-28"><a href="#cb473-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb473-29"><a href="#cb473-29" aria-hidden="true" tabindex="-1"></a><span class="co">(* map_hom (compose f g) = compose (map_hom f) (map_hom g) *)</span></span>
-<span id="cb473-30"><a href="#cb473-30" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (</span>
-<span id="cb473-31"><a href="#cb473-31" aria-hidden="true" tabindex="-1"></a>  ListTypedFunctor.map_hom (FunCat.compose f g) xs</span>
-<span id="cb473-32"><a href="#cb473-32" aria-hidden="true" tabindex="-1"></a>  = FunCat.compose (ListTypedFunctor.map_hom f)</span>
-<span id="cb473-33"><a href="#cb473-33" aria-hidden="true" tabindex="-1"></a>      (ListTypedFunctor.map_hom g) xs)</span></code></pre></div>
+<div class="sourceCode" id="cb484"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb484-1"><a href="#cb484-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> CATEGORY = <span class="kw">sig</span></span>
+<span id="cb484-2"><a href="#cb484-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom</span>
+<span id="cb484-3"><a href="#cb484-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> id : (&#39;a, &#39;a) hom</span>
+<span id="cb484-4"><a href="#cb484-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> compose : (&#39;b, &#39;c) hom -&gt; (&#39;a, &#39;b) hom -&gt; (&#39;a, &#39;c) hom</span>
+<span id="cb484-5"><a href="#cb484-5" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb484-6"><a href="#cb484-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb484-7"><a href="#cb484-7" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> TYPED_FUNCTOR = <span class="kw">sig</span></span>
+<span id="cb484-8"><a href="#cb484-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Source : CATEGORY</span>
+<span id="cb484-9"><a href="#cb484-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Target : CATEGORY</span>
+<span id="cb484-10"><a href="#cb484-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a obj                  <span class="co">(* object mapping *)</span></span>
+<span id="cb484-11"><a href="#cb484-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> map_hom : (&#39;a, &#39;b) Source.hom -&gt; (&#39;a obj, &#39;b obj) Target.hom</span>
+<span id="cb484-12"><a href="#cb484-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* Laws: *)</span></span>
+<span id="cb484-13"><a href="#cb484-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map_hom id = id *)</span></span>
+<span id="cb484-14"><a href="#cb484-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">(* map_hom (compose f g) = compose (map_hom f) (map_hom g) *)</span></span>
+<span id="cb484-15"><a href="#cb484-15" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<div class="sourceCode" id="cb485"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb485-1"><a href="#cb485-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* FunCat: the category of OCaml functions *)</span></span>
+<span id="cb485-2"><a href="#cb485-2" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FunCat : CATEGORY <span class="kw">with</span> <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b = <span class="kw">struct</span></span>
+<span id="cb485-3"><a href="#cb485-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b</span>
+<span id="cb485-4"><a href="#cb485-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> id x = x</span>
+<span id="cb485-5"><a href="#cb485-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> compose f g x = f (g x)</span>
+<span id="cb485-6"><a href="#cb485-6" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb485-7"><a href="#cb485-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb485-8"><a href="#cb485-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* List is a typed functor from FunCat to FunCat: *)</span></span>
+<span id="cb485-9"><a href="#cb485-9" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Object mapping: &#39;a ↦ &#39;a list *)</span></span>
+<span id="cb485-10"><a href="#cb485-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* - Morphism mapping: (f : &#39;a -&gt; &#39;b) ↦ (List.map f : &#39;a list -&gt; &#39;b list) *)</span></span>
+<span id="cb485-11"><a href="#cb485-11" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ListTypedFunctor : TYPED_FUNCTOR</span>
+<span id="cb485-12"><a href="#cb485-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">with</span> <span class="kw">module</span> Source = FunCat</span>
+<span id="cb485-13"><a href="#cb485-13" aria-hidden="true" tabindex="-1"></a>   <span class="kw">and</span> <span class="kw">module</span> Target = FunCat</span>
+<span id="cb485-14"><a href="#cb485-14" aria-hidden="true" tabindex="-1"></a>   <span class="kw">and</span> <span class="kw">type</span> &#39;a obj = &#39;a <span class="dt">list</span> = <span class="kw">struct</span></span>
+<span id="cb485-15"><a href="#cb485-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Source = FunCat</span>
+<span id="cb485-16"><a href="#cb485-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">module</span> Target = FunCat</span>
+<span id="cb485-17"><a href="#cb485-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a obj = &#39;a <span class="dt">list</span></span>
+<span id="cb485-18"><a href="#cb485-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> map_hom f = <span class="dt">List</span>.map f</span>
+<span id="cb485-19"><a href="#cb485-19" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb485-20"><a href="#cb485-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb485-21"><a href="#cb485-21" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify functor laws: *)</span></span>
+<span id="cb485-22"><a href="#cb485-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x + <span class="dv">1</span></span>
+<span id="cb485-23"><a href="#cb485-23" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = x * <span class="dv">2</span></span>
+<span id="cb485-24"><a href="#cb485-24" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> xs = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>]</span>
+<span id="cb485-25"><a href="#cb485-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb485-26"><a href="#cb485-26" aria-hidden="true" tabindex="-1"></a><span class="co">(* map_hom id = id *)</span></span>
+<span id="cb485-27"><a href="#cb485-27" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (ListTypedFunctor.map_hom FunCat.id xs = FunCat.id xs)</span>
+<span id="cb485-28"><a href="#cb485-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb485-29"><a href="#cb485-29" aria-hidden="true" tabindex="-1"></a><span class="co">(* map_hom (compose f g) = compose (map_hom f) (map_hom g) *)</span></span>
+<span id="cb485-30"><a href="#cb485-30" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (</span>
+<span id="cb485-31"><a href="#cb485-31" aria-hidden="true" tabindex="-1"></a>  ListTypedFunctor.map_hom (FunCat.compose f g) xs</span>
+<span id="cb485-32"><a href="#cb485-32" aria-hidden="true" tabindex="-1"></a>  = FunCat.compose (ListTypedFunctor.map_hom f)</span>
+<span id="cb485-33"><a href="#cb485-33" aria-hidden="true" tabindex="-1"></a>      (ListTypedFunctor.map_hom g) xs)</span></code></pre></div>
 <p>This ties the three views together:
 <code>ListTypedFunctor.map_hom</code> is the same operation as
 <code>ListFunctor.map</code>, but expressed as a morphism-to-morphism
@@ -16273,56 +16539,56 @@ automatically a natural transformation, because <em>parametric
 polymorphism guarantees naturality</em>. This is a consequence of the
 “free theorems” result (Wadler, 1989): a polymorphic function cannot
 inspect its type argument, so it must commute with <code>map</code>.</p>
-<div class="sourceCode" id="cb474"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb474-1"><a href="#cb474-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation: &#39;a list -&gt; &#39;a option *)</span></span>
-<span id="cb474-2"><a href="#cb474-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> head_opt : &#39;a <span class="dt">list</span> -&gt; &#39;a <span class="dt">option</span> = <span class="kw">function</span></span>
-<span id="cb474-3"><a href="#cb474-3" aria-hidden="true" tabindex="-1"></a>  | [] -&gt; <span class="dt">None</span></span>
-<span id="cb474-4"><a href="#cb474-4" aria-hidden="true" tabindex="-1"></a>  | x :: _ -&gt; <span class="dt">Some</span> x</span>
-<span id="cb474-5"><a href="#cb474-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb474-6"><a href="#cb474-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation: &#39;a option -&gt; &#39;a list *)</span></span>
-<span id="cb474-7"><a href="#cb474-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> option_to_list : &#39;a <span class="dt">option</span> -&gt; &#39;a <span class="dt">list</span> = <span class="kw">function</span></span>
-<span id="cb474-8"><a href="#cb474-8" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">None</span> -&gt; []</span>
-<span id="cb474-9"><a href="#cb474-9" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Some</span> x -&gt; [x]</span>
-<span id="cb474-10"><a href="#cb474-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb474-11"><a href="#cb474-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* Naturality: map commutes with the transformation *)</span></span>
-<span id="cb474-12"><a href="#cb474-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x * <span class="dv">2</span></span>
-<span id="cb474-13"><a href="#cb474-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb474-14"><a href="#cb474-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* head_opt ∘ List.map f = Option.map f ∘ head_opt *)</span></span>
-<span id="cb474-15"><a href="#cb474-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> test_input = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>]</span>
-<span id="cb474-16"><a href="#cb474-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
-<span id="cb474-17"><a href="#cb474-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (head_opt (<span class="dt">List</span>.map f test_input)</span>
-<span id="cb474-18"><a href="#cb474-18" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">Option</span>.map f (head_opt test_input))</span>
-<span id="cb474-19"><a href="#cb474-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb474-20"><a href="#cb474-20" aria-hidden="true" tabindex="-1"></a><span class="co">(* option_to_list ∘ Option.map f = List.map f ∘ option_to_list *)</span></span>
-<span id="cb474-21"><a href="#cb474-21" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> test_opt = <span class="dt">Some</span> <span class="dv">5</span></span>
-<span id="cb474-22"><a href="#cb474-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
-<span id="cb474-23"><a href="#cb474-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (option_to_list (<span class="dt">Option</span>.map f test_opt)</span>
-<span id="cb474-24"><a href="#cb474-24" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">List</span>.map f (option_to_list test_opt))</span></code></pre></div>
+<div class="sourceCode" id="cb486"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb486-1"><a href="#cb486-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation: &#39;a list -&gt; &#39;a option *)</span></span>
+<span id="cb486-2"><a href="#cb486-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> head_opt : &#39;a <span class="dt">list</span> -&gt; &#39;a <span class="dt">option</span> = <span class="kw">function</span></span>
+<span id="cb486-3"><a href="#cb486-3" aria-hidden="true" tabindex="-1"></a>  | [] -&gt; <span class="dt">None</span></span>
+<span id="cb486-4"><a href="#cb486-4" aria-hidden="true" tabindex="-1"></a>  | x :: _ -&gt; <span class="dt">Some</span> x</span>
+<span id="cb486-5"><a href="#cb486-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb486-6"><a href="#cb486-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation: &#39;a option -&gt; &#39;a list *)</span></span>
+<span id="cb486-7"><a href="#cb486-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> option_to_list : &#39;a <span class="dt">option</span> -&gt; &#39;a <span class="dt">list</span> = <span class="kw">function</span></span>
+<span id="cb486-8"><a href="#cb486-8" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">None</span> -&gt; []</span>
+<span id="cb486-9"><a href="#cb486-9" aria-hidden="true" tabindex="-1"></a>  | <span class="dt">Some</span> x -&gt; [x]</span>
+<span id="cb486-10"><a href="#cb486-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb486-11"><a href="#cb486-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* Naturality: map commutes with the transformation *)</span></span>
+<span id="cb486-12"><a href="#cb486-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x * <span class="dv">2</span></span>
+<span id="cb486-13"><a href="#cb486-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb486-14"><a href="#cb486-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* head_opt ∘ List.map f = Option.map f ∘ head_opt *)</span></span>
+<span id="cb486-15"><a href="#cb486-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> test_input = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>]</span>
+<span id="cb486-16"><a href="#cb486-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
+<span id="cb486-17"><a href="#cb486-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (head_opt (<span class="dt">List</span>.map f test_input)</span>
+<span id="cb486-18"><a href="#cb486-18" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">Option</span>.map f (head_opt test_input))</span>
+<span id="cb486-19"><a href="#cb486-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb486-20"><a href="#cb486-20" aria-hidden="true" tabindex="-1"></a><span class="co">(* option_to_list ∘ Option.map f = List.map f ∘ option_to_list *)</span></span>
+<span id="cb486-21"><a href="#cb486-21" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> test_opt = <span class="dt">Some</span> <span class="dv">5</span></span>
+<span id="cb486-22"><a href="#cb486-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
+<span id="cb486-23"><a href="#cb486-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (option_to_list (<span class="dt">Option</span>.map f test_opt)</span>
+<span id="cb486-24"><a href="#cb486-24" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">List</span>.map f (option_to_list test_opt))</span></code></pre></div>
 <p>This is remarkable: we did not <em>prove</em> that
 <code>head_opt</code> satisfies the naturality condition – the type
 system <em>guarantees</em> it. Any function of type
 <code>'a list -&gt; 'a option</code> is automatically natural.
 Parametricity gives naturality for free.</p>
 <h3 id="more-examples">More Examples</h3>
-<div class="sourceCode" id="cb475"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb475-1"><a href="#cb475-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* length : &#39;a list -&gt; int *)</span></span>
-<span id="cb475-2"><a href="#cb475-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* This is a natural transformation from the List functor *)</span></span>
-<span id="cb475-3"><a href="#cb475-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* to the constant functor K_int (which maps everything to int). *)</span></span>
-<span id="cb475-4"><a href="#cb475-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* Naturality says: length (List.map f xs) = length xs *)</span></span>
-<span id="cb475-5"><a href="#cb475-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (<span class="dt">List</span>.length (<span class="dt">List</span>.map f [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>]) = <span class="dt">List</span>.length [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>])</span>
-<span id="cb475-6"><a href="#cb475-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb475-7"><a href="#cb475-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* rev : &#39;a list -&gt; &#39;a list *)</span></span>
-<span id="cb475-8"><a href="#cb475-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation from List to List. *)</span></span>
-<span id="cb475-9"><a href="#cb475-9" aria-hidden="true" tabindex="-1"></a><span class="co">(* Naturality: List.map f (List.rev xs) = List.rev (List.map f xs) *)</span></span>
-<span id="cb475-10"><a href="#cb475-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
-<span id="cb475-11"><a href="#cb475-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (<span class="dt">List</span>.map f (<span class="dt">List</span>.rev [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>])</span>
-<span id="cb475-12"><a href="#cb475-12" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">List</span>.rev (<span class="dt">List</span>.map f [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>]))</span>
-<span id="cb475-13"><a href="#cb475-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb475-14"><a href="#cb475-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* flatten : &#39;a list list -&gt; &#39;a list *)</span></span>
-<span id="cb475-15"><a href="#cb475-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation from List ∘ List to List. *)</span></span>
-<span id="cb475-16"><a href="#cb475-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
-<span id="cb475-17"><a href="#cb475-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (<span class="dt">List</span>.flatten (<span class="dt">List</span>.map (<span class="dt">List</span>.map f) [[<span class="dv">1</span>;<span class="dv">2</span>];[<span class="dv">3</span>]])</span>
-<span id="cb475-18"><a href="#cb475-18" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">List</span>.map f (<span class="dt">List</span>.flatten [[<span class="dv">1</span>;<span class="dv">2</span>];[<span class="dv">3</span>]]))</span></code></pre></div>
+<div class="sourceCode" id="cb487"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb487-1"><a href="#cb487-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* length : &#39;a list -&gt; int *)</span></span>
+<span id="cb487-2"><a href="#cb487-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* This is a natural transformation from the List functor *)</span></span>
+<span id="cb487-3"><a href="#cb487-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* to the constant functor K_int (which maps everything to int). *)</span></span>
+<span id="cb487-4"><a href="#cb487-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* Naturality says: length (List.map f xs) = length xs *)</span></span>
+<span id="cb487-5"><a href="#cb487-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (<span class="dt">List</span>.length (<span class="dt">List</span>.map f [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>]) = <span class="dt">List</span>.length [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>])</span>
+<span id="cb487-6"><a href="#cb487-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb487-7"><a href="#cb487-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* rev : &#39;a list -&gt; &#39;a list *)</span></span>
+<span id="cb487-8"><a href="#cb487-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation from List to List. *)</span></span>
+<span id="cb487-9"><a href="#cb487-9" aria-hidden="true" tabindex="-1"></a><span class="co">(* Naturality: List.map f (List.rev xs) = List.rev (List.map f xs) *)</span></span>
+<span id="cb487-10"><a href="#cb487-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
+<span id="cb487-11"><a href="#cb487-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (<span class="dt">List</span>.map f (<span class="dt">List</span>.rev [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>])</span>
+<span id="cb487-12"><a href="#cb487-12" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">List</span>.rev (<span class="dt">List</span>.map f [<span class="dv">1</span>;<span class="dv">2</span>;<span class="dv">3</span>]))</span>
+<span id="cb487-13"><a href="#cb487-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb487-14"><a href="#cb487-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* flatten : &#39;a list list -&gt; &#39;a list *)</span></span>
+<span id="cb487-15"><a href="#cb487-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Natural transformation from List ∘ List to List. *)</span></span>
+<span id="cb487-16"><a href="#cb487-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
+<span id="cb487-17"><a href="#cb487-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> (<span class="dt">List</span>.flatten (<span class="dt">List</span>.map (<span class="dt">List</span>.map f) [[<span class="dv">1</span>;<span class="dv">2</span>];[<span class="dv">3</span>]])</span>
+<span id="cb487-18"><a href="#cb487-18" aria-hidden="true" tabindex="-1"></a>        = <span class="dt">List</span>.map f (<span class="dt">List</span>.flatten [[<span class="dv">1</span>;<span class="dv">2</span>];[<span class="dv">3</span>]]))</span></code></pre></div>
 <h3 id="natural-transformations-compose">Natural Transformations
 Compose</h3>
 <p>Natural transformations can be composed “vertically” (composing <span
@@ -16357,18 +16623,18 @@ B</span> (product with <span class="math inline">B</span>) and the right
 adjoint is <span class="math inline">G(C) = B \to C</span> (exponential
 by <span class="math inline">B</span>). The <code>curry</code> and
 <code>uncurry</code> functions witness this adjunction:</p>
-<div class="sourceCode" id="cb476"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb476-1"><a href="#cb476-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> curry f a b = f (a, b)</span>
-<span id="cb476-2"><a href="#cb476-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> uncurry f (a, b) = f a b</span>
-<span id="cb476-3"><a href="#cb476-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb476-4"><a href="#cb476-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* These are inverses: *)</span></span>
-<span id="cb476-5"><a href="#cb476-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f_uncurried (x, y) = x + y</span>
-<span id="cb476-6"><a href="#cb476-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f_curried x y = x + y</span>
-<span id="cb476-7"><a href="#cb476-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb476-8"><a href="#cb476-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (curry f_uncurried <span class="dv">3</span> <span class="dv">4</span> = <span class="dv">7</span>)</span>
-<span id="cb476-9"><a href="#cb476-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (uncurry f_curried (<span class="dv">3</span>, <span class="dv">4</span>) = <span class="dv">7</span>)</span>
-<span id="cb476-10"><a href="#cb476-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (curry (uncurry f_curried) <span class="dv">3</span> <span class="dv">4</span> = f_curried <span class="dv">3</span> <span class="dv">4</span>)</span>
-<span id="cb476-11"><a href="#cb476-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (uncurry (curry f_uncurried) (<span class="dv">3</span>, <span class="dv">4</span>) = f_uncurried (<span class="dv">3</span>, <span class="dv">4</span>))</span></code></pre></div>
+<div class="sourceCode" id="cb488"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb488-1"><a href="#cb488-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> curry f a b = f (a, b)</span>
+<span id="cb488-2"><a href="#cb488-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> uncurry f (a, b) = f a b</span>
+<span id="cb488-3"><a href="#cb488-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb488-4"><a href="#cb488-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* These are inverses: *)</span></span>
+<span id="cb488-5"><a href="#cb488-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f_uncurried (x, y) = x + y</span>
+<span id="cb488-6"><a href="#cb488-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f_curried x y = x + y</span>
+<span id="cb488-7"><a href="#cb488-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb488-8"><a href="#cb488-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (curry f_uncurried <span class="dv">3</span> <span class="dv">4</span> = <span class="dv">7</span>)</span>
+<span id="cb488-9"><a href="#cb488-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (uncurry f_curried (<span class="dv">3</span>, <span class="dv">4</span>) = <span class="dv">7</span>)</span>
+<span id="cb488-10"><a href="#cb488-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (curry (uncurry f_curried) <span class="dv">3</span> <span class="dv">4</span> = f_curried <span class="dv">3</span> <span class="dv">4</span>)</span>
+<span id="cb488-11"><a href="#cb488-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (uncurry (curry f_uncurried) (<span class="dv">3</span>, <span class="dv">4</span>) = f_uncurried (<span class="dv">3</span>, <span class="dv">4</span>))</span></code></pre></div>
 <h3 id="freeforgetful-adjunctions">Free/Forgetful Adjunctions</h3>
 <p>Another important class of adjunctions: <strong>free
 constructions</strong>. The <em>free monoid</em> on a set <span
@@ -16382,46 +16648,46 @@ monoid back to its underlying type. The adjunction says:</p>
 class="math inline">M</span> is completely determined by where it sends
 each element – that is, by a function <code>'a -&gt; M.t</code>. This is
 exactly <code>List.fold_right</code>:</p>
-<div class="sourceCode" id="cb477"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb477-1"><a href="#cb477-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The free monoid adjunction, witnessed by fold_right: *)</span></span>
-<span id="cb477-2"><a href="#cb477-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* A monoid homomorphism from &#39;a list is determined by *)</span></span>
-<span id="cb477-3"><a href="#cb477-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* where single elements go. *)</span></span>
-<span id="cb477-4"><a href="#cb477-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb477-5"><a href="#cb477-5" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> MONOID = <span class="kw">sig</span></span>
-<span id="cb477-6"><a href="#cb477-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t</span>
-<span id="cb477-7"><a href="#cb477-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> empty : t</span>
-<span id="cb477-8"><a href="#cb477-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> append : t -&gt; t -&gt; t</span>
-<span id="cb477-9"><a href="#cb477-9" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb477-10"><a href="#cb477-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb477-11"><a href="#cb477-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* Given a function f : &#39;a -&gt; M.t, extend it to a *)</span></span>
-<span id="cb477-12"><a href="#cb477-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* monoid homomorphism &#39;a list -&gt; M.t *)</span></span>
-<span id="cb477-13"><a href="#cb477-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> extend_to_hom</span>
-<span id="cb477-14"><a href="#cb477-14" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">type</span> m) (<span class="kw">module</span> M : MONOID <span class="kw">with</span> <span class="kw">type</span> t = m)</span>
-<span id="cb477-15"><a href="#cb477-15" aria-hidden="true" tabindex="-1"></a>    (f : &#39;a -&gt; m) (xs : &#39;a <span class="dt">list</span>) : m =</span>
-<span id="cb477-16"><a href="#cb477-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.fold_right (<span class="kw">fun</span> x acc -&gt; M.append (f x) acc) xs M.empty</span>
-<span id="cb477-17"><a href="#cb477-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb477-18"><a href="#cb477-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: summing a list via the (int, +, 0) monoid *)</span></span>
-<span id="cb477-19"><a href="#cb477-19" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> IntAdd : MONOID <span class="kw">with</span> <span class="kw">type</span> t = <span class="dt">int</span> = <span class="kw">struct</span></span>
-<span id="cb477-20"><a href="#cb477-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = <span class="dt">int</span></span>
-<span id="cb477-21"><a href="#cb477-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = <span class="dv">0</span></span>
-<span id="cb477-22"><a href="#cb477-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( + )</span>
-<span id="cb477-23"><a href="#cb477-23" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb477-24"><a href="#cb477-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb477-25"><a href="#cb477-25" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> sum xs = extend_to_hom (<span class="kw">module</span> IntAdd) <span class="dt">Fun</span>.id xs</span>
-<span id="cb477-26"><a href="#cb477-26" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (sum [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>; <span class="dv">4</span>] = <span class="dv">10</span>)</span>
-<span id="cb477-27"><a href="#cb477-27" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb477-28"><a href="#cb477-28" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: concatenating strings *)</span></span>
-<span id="cb477-29"><a href="#cb477-29" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> StringConcat : MONOID <span class="kw">with</span> <span class="kw">type</span> t = <span class="dt">string</span> = <span class="kw">struct</span></span>
-<span id="cb477-30"><a href="#cb477-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = <span class="dt">string</span></span>
-<span id="cb477-31"><a href="#cb477-31" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = <span class="st">&quot;&quot;</span></span>
-<span id="cb477-32"><a href="#cb477-32" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( ^ )</span>
-<span id="cb477-33"><a href="#cb477-33" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb477-34"><a href="#cb477-34" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb477-35"><a href="#cb477-35" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> concat_with_spaces xs =</span>
-<span id="cb477-36"><a href="#cb477-36" aria-hidden="true" tabindex="-1"></a>  extend_to_hom (<span class="kw">module</span> StringConcat)</span>
-<span id="cb477-37"><a href="#cb477-37" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">fun</span> s -&gt; <span class="kw">if</span> s = <span class="st">&quot;&quot;</span> <span class="kw">then</span> <span class="st">&quot;&quot;</span> <span class="kw">else</span> s ^ <span class="st">&quot; &quot;</span>) xs</span>
-<span id="cb477-38"><a href="#cb477-38" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb477-39"><a href="#cb477-39" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (<span class="dt">String</span>.trim (concat_with_spaces [<span class="st">&quot;hello&quot;</span>; <span class="st">&quot;world&quot;</span>]) = <span class="st">&quot;hello world&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb489"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb489-1"><a href="#cb489-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The free monoid adjunction, witnessed by fold_right: *)</span></span>
+<span id="cb489-2"><a href="#cb489-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* A monoid homomorphism from &#39;a list is determined by *)</span></span>
+<span id="cb489-3"><a href="#cb489-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* where single elements go. *)</span></span>
+<span id="cb489-4"><a href="#cb489-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb489-5"><a href="#cb489-5" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> MONOID = <span class="kw">sig</span></span>
+<span id="cb489-6"><a href="#cb489-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t</span>
+<span id="cb489-7"><a href="#cb489-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> empty : t</span>
+<span id="cb489-8"><a href="#cb489-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> append : t -&gt; t -&gt; t</span>
+<span id="cb489-9"><a href="#cb489-9" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb489-10"><a href="#cb489-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb489-11"><a href="#cb489-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* Given a function f : &#39;a -&gt; M.t, extend it to a *)</span></span>
+<span id="cb489-12"><a href="#cb489-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* monoid homomorphism &#39;a list -&gt; M.t *)</span></span>
+<span id="cb489-13"><a href="#cb489-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> extend_to_hom</span>
+<span id="cb489-14"><a href="#cb489-14" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">type</span> m) (<span class="kw">module</span> M : MONOID <span class="kw">with</span> <span class="kw">type</span> t = m)</span>
+<span id="cb489-15"><a href="#cb489-15" aria-hidden="true" tabindex="-1"></a>    (f : &#39;a -&gt; m) (xs : &#39;a <span class="dt">list</span>) : m =</span>
+<span id="cb489-16"><a href="#cb489-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.fold_right (<span class="kw">fun</span> x acc -&gt; M.append (f x) acc) xs M.empty</span>
+<span id="cb489-17"><a href="#cb489-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb489-18"><a href="#cb489-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: summing a list via the (int, +, 0) monoid *)</span></span>
+<span id="cb489-19"><a href="#cb489-19" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> IntAdd : MONOID <span class="kw">with</span> <span class="kw">type</span> t = <span class="dt">int</span> = <span class="kw">struct</span></span>
+<span id="cb489-20"><a href="#cb489-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = <span class="dt">int</span></span>
+<span id="cb489-21"><a href="#cb489-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = <span class="dv">0</span></span>
+<span id="cb489-22"><a href="#cb489-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( + )</span>
+<span id="cb489-23"><a href="#cb489-23" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb489-24"><a href="#cb489-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb489-25"><a href="#cb489-25" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> sum xs = extend_to_hom (<span class="kw">module</span> IntAdd) <span class="dt">Fun</span>.id xs</span>
+<span id="cb489-26"><a href="#cb489-26" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (sum [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>; <span class="dv">4</span>] = <span class="dv">10</span>)</span>
+<span id="cb489-27"><a href="#cb489-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb489-28"><a href="#cb489-28" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: concatenating strings *)</span></span>
+<span id="cb489-29"><a href="#cb489-29" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> StringConcat : MONOID <span class="kw">with</span> <span class="kw">type</span> t = <span class="dt">string</span> = <span class="kw">struct</span></span>
+<span id="cb489-30"><a href="#cb489-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> t = <span class="dt">string</span></span>
+<span id="cb489-31"><a href="#cb489-31" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> empty = <span class="st">&quot;&quot;</span></span>
+<span id="cb489-32"><a href="#cb489-32" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> append = ( ^ )</span>
+<span id="cb489-33"><a href="#cb489-33" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb489-34"><a href="#cb489-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb489-35"><a href="#cb489-35" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> concat_with_spaces xs =</span>
+<span id="cb489-36"><a href="#cb489-36" aria-hidden="true" tabindex="-1"></a>  extend_to_hom (<span class="kw">module</span> StringConcat)</span>
+<span id="cb489-37"><a href="#cb489-37" aria-hidden="true" tabindex="-1"></a>    (<span class="kw">fun</span> s -&gt; <span class="kw">if</span> s = <span class="st">&quot;&quot;</span> <span class="kw">then</span> <span class="st">&quot;&quot;</span> <span class="kw">else</span> s ^ <span class="st">&quot; &quot;</span>) xs</span>
+<span id="cb489-38"><a href="#cb489-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb489-39"><a href="#cb489-39" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (<span class="dt">String</span>.trim (concat_with_spaces [<span class="st">&quot;hello&quot;</span>; <span class="st">&quot;world&quot;</span>]) = <span class="st">&quot;hello world&quot;</span>)</span></code></pre></div>
 <p>The free monad adjunction from Chapter 8 works the same way: a monad
 homomorphism from the free monad on effects <span
 class="math inline">E</span> to any monad <span
@@ -16440,24 +16706,24 @@ that:</p>
 <span class="math inline">g \circ f : A \to A</span>, where the
 <em>closed elements</em> (fixed points of <span class="math inline">g
 \circ f</span>) form a complete lattice.</p>
-<div class="sourceCode" id="cb478"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb478-1"><a href="#cb478-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A simple Galois connection: *)</span></span>
-<span id="cb478-2"><a href="#cb478-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* floor and ceiling between reals and integers *)</span></span>
-<span id="cb478-3"><a href="#cb478-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* f = floor : float -&gt; int (left adjoint) *)</span></span>
-<span id="cb478-4"><a href="#cb478-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* g = embed : int -&gt; float (right adjoint) *)</span></span>
-<span id="cb478-5"><a href="#cb478-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* floor(x) &lt;= n  iff  x &lt;= float(n) *)</span></span>
-<span id="cb478-6"><a href="#cb478-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb478-7"><a href="#cb478-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> galois_floor (x : <span class="dt">float</span>) : <span class="dt">int</span> = <span class="dt">int_of_float</span> (Float.<span class="dt">floor</span> x)</span>
-<span id="cb478-8"><a href="#cb478-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> galois_embed (n : <span class="dt">int</span>) : <span class="dt">float</span> = <span class="dt">float_of_int</span> n</span>
-<span id="cb478-9"><a href="#cb478-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb478-10"><a href="#cb478-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify the Galois connection property: *)</span></span>
-<span id="cb478-11"><a href="#cb478-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
-<span id="cb478-12"><a href="#cb478-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> x = <span class="fl">3.7</span> <span class="kw">and</span> n = <span class="dv">4</span> <span class="kw">in</span></span>
-<span id="cb478-13"><a href="#cb478-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> ((galois_floor x &lt;= n) = (x &lt;= galois_embed n))</span>
-<span id="cb478-14"><a href="#cb478-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb478-15"><a href="#cb478-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
-<span id="cb478-16"><a href="#cb478-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> x = <span class="fl">4.0</span> <span class="kw">and</span> n = <span class="dv">3</span> <span class="kw">in</span></span>
-<span id="cb478-17"><a href="#cb478-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> ((galois_floor x &lt;= n) = (x &lt;= galois_embed n))</span></code></pre></div>
+<div class="sourceCode" id="cb490"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb490-1"><a href="#cb490-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A simple Galois connection: *)</span></span>
+<span id="cb490-2"><a href="#cb490-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* floor and ceiling between reals and integers *)</span></span>
+<span id="cb490-3"><a href="#cb490-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* f = floor : float -&gt; int (left adjoint) *)</span></span>
+<span id="cb490-4"><a href="#cb490-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* g = embed : int -&gt; float (right adjoint) *)</span></span>
+<span id="cb490-5"><a href="#cb490-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* floor(x) &lt;= n  iff  x &lt;= float(n) *)</span></span>
+<span id="cb490-6"><a href="#cb490-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb490-7"><a href="#cb490-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> galois_floor (x : <span class="dt">float</span>) : <span class="dt">int</span> = <span class="dt">int_of_float</span> (Float.<span class="dt">floor</span> x)</span>
+<span id="cb490-8"><a href="#cb490-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> galois_embed (n : <span class="dt">int</span>) : <span class="dt">float</span> = <span class="dt">float_of_int</span> n</span>
+<span id="cb490-9"><a href="#cb490-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb490-10"><a href="#cb490-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify the Galois connection property: *)</span></span>
+<span id="cb490-11"><a href="#cb490-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
+<span id="cb490-12"><a href="#cb490-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> x = <span class="fl">3.7</span> <span class="kw">and</span> n = <span class="dv">4</span> <span class="kw">in</span></span>
+<span id="cb490-13"><a href="#cb490-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> ((galois_floor x &lt;= n) = (x &lt;= galois_embed n))</span>
+<span id="cb490-14"><a href="#cb490-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb490-15"><a href="#cb490-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () =</span>
+<span id="cb490-16"><a href="#cb490-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> x = <span class="fl">4.0</span> <span class="kw">and</span> n = <span class="dv">3</span> <span class="kw">in</span></span>
+<span id="cb490-17"><a href="#cb490-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">assert</span> ((galois_floor x &lt;= n) = (x &lt;= galois_embed n))</span></code></pre></div>
 <h3 id="formal-concept-analysis">Formal Concept Analysis</h3>
 <p>A deep application of Galois connections is <strong>Formal Concept
 Analysis</strong> (Wille, 1982). Given a binary relation <span
@@ -16475,45 +16741,45 @@ connection. The closed pairs <span class="math inline">(S, T)</span>
 where <span class="math inline">S = g(T)</span> and <span
 class="math inline">T = f(S)</span> are called <strong>formal
 concepts</strong> and form a lattice.</p>
-<div class="sourceCode" id="cb479"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb479-1"><a href="#cb479-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Formal concept analysis: a small example *)</span></span>
-<span id="cb479-2"><a href="#cb479-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Objects: animals; Attributes: properties *)</span></span>
-<span id="cb479-3"><a href="#cb479-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* Relation: &quot;animal has property&quot; *)</span></span>
-<span id="cb479-4"><a href="#cb479-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-5"><a href="#cb479-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> animals = [| <span class="st">&quot;dog&quot;</span>; <span class="st">&quot;cat&quot;</span>; <span class="st">&quot;salmon&quot;</span>; <span class="st">&quot;eagle&quot;</span> |]</span>
-<span id="cb479-6"><a href="#cb479-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> attributes = [| <span class="st">&quot;legs&quot;</span>; <span class="st">&quot;flies&quot;</span>; <span class="st">&quot;swims&quot;</span>; <span class="st">&quot;fur&quot;</span> |]</span>
-<span id="cb479-7"><a href="#cb479-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-8"><a href="#cb479-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Incidence matrix: animal × attribute *)</span></span>
-<span id="cb479-9"><a href="#cb479-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> relation = [|</span>
-<span id="cb479-10"><a href="#cb479-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">(*         legs  flies swims fur *)</span></span>
-<span id="cb479-11"><a href="#cb479-11" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">true</span>;  <span class="kw">false</span>; <span class="kw">false</span>; <span class="kw">true</span>  |];  <span class="co">(* dog *)</span></span>
-<span id="cb479-12"><a href="#cb479-12" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">true</span>;  <span class="kw">false</span>; <span class="kw">false</span>; <span class="kw">true</span>  |];  <span class="co">(* cat *)</span></span>
-<span id="cb479-13"><a href="#cb479-13" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">false</span>; <span class="kw">false</span>; <span class="kw">true</span>;  <span class="kw">false</span> |];  <span class="co">(* salmon *)</span></span>
-<span id="cb479-14"><a href="#cb479-14" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">false</span>; <span class="kw">true</span>;  <span class="kw">false</span>; <span class="kw">false</span> |];  <span class="co">(* eagle *)</span></span>
-<span id="cb479-15"><a href="#cb479-15" aria-hidden="true" tabindex="-1"></a>|]</span>
-<span id="cb479-16"><a href="#cb479-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-17"><a href="#cb479-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> n_obj = <span class="dt">Array</span>.length animals</span>
-<span id="cb479-18"><a href="#cb479-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> n_att = <span class="dt">Array</span>.length attributes</span>
-<span id="cb479-19"><a href="#cb479-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-20"><a href="#cb479-20" aria-hidden="true" tabindex="-1"></a><span class="co">(* f: set of objects -&gt; common attributes *)</span></span>
-<span id="cb479-21"><a href="#cb479-21" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> common_attributes (objs : <span class="dt">int</span> <span class="dt">list</span>) : <span class="dt">int</span> <span class="dt">list</span> =</span>
-<span id="cb479-22"><a href="#cb479-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.init n_att <span class="dt">Fun</span>.id |&gt; <span class="dt">List</span>.filter (<span class="kw">fun</span> j -&gt;</span>
-<span id="cb479-23"><a href="#cb479-23" aria-hidden="true" tabindex="-1"></a>    <span class="dt">List</span>.for_all (<span class="kw">fun</span> i -&gt; relation.(i).(j)) objs)</span>
-<span id="cb479-24"><a href="#cb479-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-25"><a href="#cb479-25" aria-hidden="true" tabindex="-1"></a><span class="co">(* g: set of attributes -&gt; objects sharing all *)</span></span>
-<span id="cb479-26"><a href="#cb479-26" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> shared_objects (atts : <span class="dt">int</span> <span class="dt">list</span>) : <span class="dt">int</span> <span class="dt">list</span> =</span>
-<span id="cb479-27"><a href="#cb479-27" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.init n_obj <span class="dt">Fun</span>.id |&gt; <span class="dt">List</span>.filter (<span class="kw">fun</span> i -&gt;</span>
-<span id="cb479-28"><a href="#cb479-28" aria-hidden="true" tabindex="-1"></a>    <span class="dt">List</span>.for_all (<span class="kw">fun</span> j -&gt; relation.(i).(j)) atts)</span>
-<span id="cb479-29"><a href="#cb479-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-30"><a href="#cb479-30" aria-hidden="true" tabindex="-1"></a><span class="co">(* Closure operator: g ∘ f *)</span></span>
-<span id="cb479-31"><a href="#cb479-31" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> closure objs = shared_objects (common_attributes objs)</span>
-<span id="cb479-32"><a href="#cb479-32" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-33"><a href="#cb479-33" aria-hidden="true" tabindex="-1"></a><span class="co">(* {dog} closes to {dog, cat}: they share exactly {legs, fur} *)</span></span>
-<span id="cb479-34"><a href="#cb479-34" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (closure [<span class="dv">0</span>] = [<span class="dv">0</span>; <span class="dv">1</span>])</span>
-<span id="cb479-35"><a href="#cb479-35" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (common_attributes [<span class="dv">0</span>; <span class="dv">1</span>] = [<span class="dv">0</span>; <span class="dv">3</span>])</span>
-<span id="cb479-36"><a href="#cb479-36" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb479-37"><a href="#cb479-37" aria-hidden="true" tabindex="-1"></a><span class="co">(* {salmon} is already closed *)</span></span>
-<span id="cb479-38"><a href="#cb479-38" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (closure [<span class="dv">2</span>] = [<span class="dv">2</span>])</span></code></pre></div>
+<div class="sourceCode" id="cb491"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb491-1"><a href="#cb491-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Formal concept analysis: a small example *)</span></span>
+<span id="cb491-2"><a href="#cb491-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Objects: animals; Attributes: properties *)</span></span>
+<span id="cb491-3"><a href="#cb491-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* Relation: &quot;animal has property&quot; *)</span></span>
+<span id="cb491-4"><a href="#cb491-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-5"><a href="#cb491-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> animals = [| <span class="st">&quot;dog&quot;</span>; <span class="st">&quot;cat&quot;</span>; <span class="st">&quot;salmon&quot;</span>; <span class="st">&quot;eagle&quot;</span> |]</span>
+<span id="cb491-6"><a href="#cb491-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> attributes = [| <span class="st">&quot;legs&quot;</span>; <span class="st">&quot;flies&quot;</span>; <span class="st">&quot;swims&quot;</span>; <span class="st">&quot;fur&quot;</span> |]</span>
+<span id="cb491-7"><a href="#cb491-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-8"><a href="#cb491-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Incidence matrix: animal × attribute *)</span></span>
+<span id="cb491-9"><a href="#cb491-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> relation = [|</span>
+<span id="cb491-10"><a href="#cb491-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">(*         legs  flies swims fur *)</span></span>
+<span id="cb491-11"><a href="#cb491-11" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">true</span>;  <span class="kw">false</span>; <span class="kw">false</span>; <span class="kw">true</span>  |];  <span class="co">(* dog *)</span></span>
+<span id="cb491-12"><a href="#cb491-12" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">true</span>;  <span class="kw">false</span>; <span class="kw">false</span>; <span class="kw">true</span>  |];  <span class="co">(* cat *)</span></span>
+<span id="cb491-13"><a href="#cb491-13" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">false</span>; <span class="kw">false</span>; <span class="kw">true</span>;  <span class="kw">false</span> |];  <span class="co">(* salmon *)</span></span>
+<span id="cb491-14"><a href="#cb491-14" aria-hidden="true" tabindex="-1"></a>  [| <span class="kw">false</span>; <span class="kw">true</span>;  <span class="kw">false</span>; <span class="kw">false</span> |];  <span class="co">(* eagle *)</span></span>
+<span id="cb491-15"><a href="#cb491-15" aria-hidden="true" tabindex="-1"></a>|]</span>
+<span id="cb491-16"><a href="#cb491-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-17"><a href="#cb491-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> n_obj = <span class="dt">Array</span>.length animals</span>
+<span id="cb491-18"><a href="#cb491-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> n_att = <span class="dt">Array</span>.length attributes</span>
+<span id="cb491-19"><a href="#cb491-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-20"><a href="#cb491-20" aria-hidden="true" tabindex="-1"></a><span class="co">(* f: set of objects -&gt; common attributes *)</span></span>
+<span id="cb491-21"><a href="#cb491-21" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> common_attributes (objs : <span class="dt">int</span> <span class="dt">list</span>) : <span class="dt">int</span> <span class="dt">list</span> =</span>
+<span id="cb491-22"><a href="#cb491-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.init n_att <span class="dt">Fun</span>.id |&gt; <span class="dt">List</span>.filter (<span class="kw">fun</span> j -&gt;</span>
+<span id="cb491-23"><a href="#cb491-23" aria-hidden="true" tabindex="-1"></a>    <span class="dt">List</span>.for_all (<span class="kw">fun</span> i -&gt; relation.(i).(j)) objs)</span>
+<span id="cb491-24"><a href="#cb491-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-25"><a href="#cb491-25" aria-hidden="true" tabindex="-1"></a><span class="co">(* g: set of attributes -&gt; objects sharing all *)</span></span>
+<span id="cb491-26"><a href="#cb491-26" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> shared_objects (atts : <span class="dt">int</span> <span class="dt">list</span>) : <span class="dt">int</span> <span class="dt">list</span> =</span>
+<span id="cb491-27"><a href="#cb491-27" aria-hidden="true" tabindex="-1"></a>  <span class="dt">List</span>.init n_obj <span class="dt">Fun</span>.id |&gt; <span class="dt">List</span>.filter (<span class="kw">fun</span> i -&gt;</span>
+<span id="cb491-28"><a href="#cb491-28" aria-hidden="true" tabindex="-1"></a>    <span class="dt">List</span>.for_all (<span class="kw">fun</span> j -&gt; relation.(i).(j)) atts)</span>
+<span id="cb491-29"><a href="#cb491-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-30"><a href="#cb491-30" aria-hidden="true" tabindex="-1"></a><span class="co">(* Closure operator: g ∘ f *)</span></span>
+<span id="cb491-31"><a href="#cb491-31" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> closure objs = shared_objects (common_attributes objs)</span>
+<span id="cb491-32"><a href="#cb491-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-33"><a href="#cb491-33" aria-hidden="true" tabindex="-1"></a><span class="co">(* {dog} closes to {dog, cat}: they share exactly {legs, fur} *)</span></span>
+<span id="cb491-34"><a href="#cb491-34" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (closure [<span class="dv">0</span>] = [<span class="dv">0</span>; <span class="dv">1</span>])</span>
+<span id="cb491-35"><a href="#cb491-35" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (common_attributes [<span class="dv">0</span>; <span class="dv">1</span>] = [<span class="dv">0</span>; <span class="dv">3</span>])</span>
+<span id="cb491-36"><a href="#cb491-36" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb491-37"><a href="#cb491-37" aria-hidden="true" tabindex="-1"></a><span class="co">(* {salmon} is already closed *)</span></span>
+<span id="cb491-38"><a href="#cb491-38" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (closure [<span class="dv">2</span>] = [<span class="dv">2</span>])</span></code></pre></div>
 <p><strong>Connection to abstract interpretation.</strong> The
 Cousot–Cousot framework (1977) for static analysis is built on Galois
 connections between concrete and abstract domains. The
@@ -16544,11 +16810,11 @@ Interface</h3>
 first-class value. Where a zipper gives you concrete navigation through
 a data structure, a lens specifies <em>how to focus</em> on a part
 without committing to a particular traversal:</p>
-<div class="sourceCode" id="cb480"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb480-1"><a href="#cb480-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;s, &#39;a) lens = {</span>
-<span id="cb480-2"><a href="#cb480-2" aria-hidden="true" tabindex="-1"></a>  get : &#39;s -&gt; &#39;a;</span>
-<span id="cb480-3"><a href="#cb480-3" aria-hidden="true" tabindex="-1"></a>  set : &#39;a -&gt; &#39;s -&gt; &#39;s;</span>
-<span id="cb480-4"><a href="#cb480-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb492"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb492-1"><a href="#cb492-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;s, &#39;a) lens = {</span>
+<span id="cb492-2"><a href="#cb492-2" aria-hidden="true" tabindex="-1"></a>  get : &#39;s -&gt; &#39;a;</span>
+<span id="cb492-3"><a href="#cb492-3" aria-hidden="true" tabindex="-1"></a>  set : &#39;a -&gt; &#39;s -&gt; &#39;s;</span>
+<span id="cb492-4"><a href="#cb492-4" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p>Here <code>'s</code> is the “whole” type and <code>'a</code> is the
 “part” type. A lens must satisfy three laws:</p>
 <ol type="1">
@@ -16559,30 +16825,30 @@ what you set)</li>
 <li><strong>Set-Set</strong>: <code>set a' (set a s) = set a' s</code>
 (setting twice is setting once)</li>
 </ol>
-<div class="sourceCode" id="cb481"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb481-1"><a href="#cb481-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A record type with two lenses *)</span></span>
-<span id="cb481-2"><a href="#cb481-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> person = { name : <span class="dt">string</span>; age : <span class="dt">int</span> }</span>
-<span id="cb481-3"><a href="#cb481-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb481-4"><a href="#cb481-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> name_lens : (person, <span class="dt">string</span>) lens = {</span>
-<span id="cb481-5"><a href="#cb481-5" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> p -&gt; p.name);</span>
-<span id="cb481-6"><a href="#cb481-6" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> n p -&gt; { p <span class="kw">with</span> name = n });</span>
-<span id="cb481-7"><a href="#cb481-7" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb481-8"><a href="#cb481-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb481-9"><a href="#cb481-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> age_lens : (person, <span class="dt">int</span>) lens = {</span>
-<span id="cb481-10"><a href="#cb481-10" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> p -&gt; p.age);</span>
-<span id="cb481-11"><a href="#cb481-11" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> a p -&gt; { p <span class="kw">with</span> age = a });</span>
-<span id="cb481-12"><a href="#cb481-12" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb481-13"><a href="#cb481-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb481-14"><a href="#cb481-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify lens laws *)</span></span>
-<span id="cb481-15"><a href="#cb481-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> alice = { name = <span class="st">&quot;Alice&quot;</span>; age = <span class="dv">30</span> }</span>
-<span id="cb481-16"><a href="#cb481-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb481-17"><a href="#cb481-17" aria-hidden="true" tabindex="-1"></a><span class="co">(* Get-Set *)</span></span>
-<span id="cb481-18"><a href="#cb481-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (name_lens.set (name_lens.get alice) alice = alice)</span>
-<span id="cb481-19"><a href="#cb481-19" aria-hidden="true" tabindex="-1"></a><span class="co">(* Set-Get *)</span></span>
-<span id="cb481-20"><a href="#cb481-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (name_lens.get (name_lens.set <span class="st">&quot;Bob&quot;</span> alice) = <span class="st">&quot;Bob&quot;</span>)</span>
-<span id="cb481-21"><a href="#cb481-21" aria-hidden="true" tabindex="-1"></a><span class="co">(* Set-Set *)</span></span>
-<span id="cb481-22"><a href="#cb481-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (name_lens.set <span class="st">&quot;Carol&quot;</span> (name_lens.set <span class="st">&quot;Bob&quot;</span> alice)</span>
-<span id="cb481-23"><a href="#cb481-23" aria-hidden="true" tabindex="-1"></a>               = name_lens.set <span class="st">&quot;Carol&quot;</span> alice)</span></code></pre></div>
+<div class="sourceCode" id="cb493"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb493-1"><a href="#cb493-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A record type with two lenses *)</span></span>
+<span id="cb493-2"><a href="#cb493-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> person = { name : <span class="dt">string</span>; age : <span class="dt">int</span> }</span>
+<span id="cb493-3"><a href="#cb493-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb493-4"><a href="#cb493-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> name_lens : (person, <span class="dt">string</span>) lens = {</span>
+<span id="cb493-5"><a href="#cb493-5" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> p -&gt; p.name);</span>
+<span id="cb493-6"><a href="#cb493-6" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> n p -&gt; { p <span class="kw">with</span> name = n });</span>
+<span id="cb493-7"><a href="#cb493-7" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb493-8"><a href="#cb493-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb493-9"><a href="#cb493-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> age_lens : (person, <span class="dt">int</span>) lens = {</span>
+<span id="cb493-10"><a href="#cb493-10" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> p -&gt; p.age);</span>
+<span id="cb493-11"><a href="#cb493-11" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> a p -&gt; { p <span class="kw">with</span> age = a });</span>
+<span id="cb493-12"><a href="#cb493-12" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb493-13"><a href="#cb493-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb493-14"><a href="#cb493-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify lens laws *)</span></span>
+<span id="cb493-15"><a href="#cb493-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> alice = { name = <span class="st">&quot;Alice&quot;</span>; age = <span class="dv">30</span> }</span>
+<span id="cb493-16"><a href="#cb493-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb493-17"><a href="#cb493-17" aria-hidden="true" tabindex="-1"></a><span class="co">(* Get-Set *)</span></span>
+<span id="cb493-18"><a href="#cb493-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (name_lens.set (name_lens.get alice) alice = alice)</span>
+<span id="cb493-19"><a href="#cb493-19" aria-hidden="true" tabindex="-1"></a><span class="co">(* Set-Get *)</span></span>
+<span id="cb493-20"><a href="#cb493-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (name_lens.get (name_lens.set <span class="st">&quot;Bob&quot;</span> alice) = <span class="st">&quot;Bob&quot;</span>)</span>
+<span id="cb493-21"><a href="#cb493-21" aria-hidden="true" tabindex="-1"></a><span class="co">(* Set-Set *)</span></span>
+<span id="cb493-22"><a href="#cb493-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (name_lens.set <span class="st">&quot;Carol&quot;</span> (name_lens.set <span class="st">&quot;Bob&quot;</span> alice)</span>
+<span id="cb493-23"><a href="#cb493-23" aria-hidden="true" tabindex="-1"></a>               = name_lens.set <span class="st">&quot;Carol&quot;</span> alice)</span></code></pre></div>
 <h3 id="lens-composition">Lens Composition</h3>
 <p>The power of lenses comes from composition. If you have a lens from
 <span class="math inline">S</span> to <span
@@ -16590,27 +16856,27 @@ class="math inline">A</span>, and a lens from <span
 class="math inline">A</span> to <span class="math inline">B</span>, you
 can compose them to get a lens from <span class="math inline">S</span>
 to <span class="math inline">B</span>:</p>
-<div class="sourceCode" id="cb482"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb482-1"><a href="#cb482-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> compose_lens (outer : (&#39;s, &#39;a) lens) (inner : (&#39;a, &#39;b) lens)</span>
-<span id="cb482-2"><a href="#cb482-2" aria-hidden="true" tabindex="-1"></a>  : (&#39;s, &#39;b) lens = {</span>
-<span id="cb482-3"><a href="#cb482-3" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> s -&gt; inner.get (outer.get s));</span>
-<span id="cb482-4"><a href="#cb482-4" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> b s -&gt; outer.set (inner.set b (outer.get s)) s);</span>
-<span id="cb482-5"><a href="#cb482-5" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb482-6"><a href="#cb482-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb482-7"><a href="#cb482-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* Nested record example *)</span></span>
-<span id="cb482-8"><a href="#cb482-8" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> company = { ceo : person; founded : <span class="dt">int</span> }</span>
-<span id="cb482-9"><a href="#cb482-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb482-10"><a href="#cb482-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> ceo_lens : (company, person) lens = {</span>
-<span id="cb482-11"><a href="#cb482-11" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> c -&gt; c.ceo);</span>
-<span id="cb482-12"><a href="#cb482-12" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> p c -&gt; { c <span class="kw">with</span> ceo = p });</span>
-<span id="cb482-13"><a href="#cb482-13" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb482-14"><a href="#cb482-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb482-15"><a href="#cb482-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> ceo_name : (company, <span class="dt">string</span>) lens = compose_lens ceo_lens name_lens</span>
-<span id="cb482-16"><a href="#cb482-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb482-17"><a href="#cb482-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> acme = { ceo = alice; founded = <span class="dv">2000</span> }</span>
-<span id="cb482-18"><a href="#cb482-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (ceo_name.get acme = <span class="st">&quot;Alice&quot;</span>)</span>
-<span id="cb482-19"><a href="#cb482-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> acme&#39; = ceo_name.set <span class="st">&quot;Bob&quot;</span> acme</span>
-<span id="cb482-20"><a href="#cb482-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (acme&#39;.ceo.name = <span class="st">&quot;Bob&quot;</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb494"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb494-1"><a href="#cb494-1" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> compose_lens (outer : (&#39;s, &#39;a) lens) (inner : (&#39;a, &#39;b) lens)</span>
+<span id="cb494-2"><a href="#cb494-2" aria-hidden="true" tabindex="-1"></a>  : (&#39;s, &#39;b) lens = {</span>
+<span id="cb494-3"><a href="#cb494-3" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> s -&gt; inner.get (outer.get s));</span>
+<span id="cb494-4"><a href="#cb494-4" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> b s -&gt; outer.set (inner.set b (outer.get s)) s);</span>
+<span id="cb494-5"><a href="#cb494-5" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb494-6"><a href="#cb494-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb494-7"><a href="#cb494-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* Nested record example *)</span></span>
+<span id="cb494-8"><a href="#cb494-8" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> company = { ceo : person; founded : <span class="dt">int</span> }</span>
+<span id="cb494-9"><a href="#cb494-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb494-10"><a href="#cb494-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> ceo_lens : (company, person) lens = {</span>
+<span id="cb494-11"><a href="#cb494-11" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> c -&gt; c.ceo);</span>
+<span id="cb494-12"><a href="#cb494-12" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> p c -&gt; { c <span class="kw">with</span> ceo = p });</span>
+<span id="cb494-13"><a href="#cb494-13" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb494-14"><a href="#cb494-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb494-15"><a href="#cb494-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> ceo_name : (company, <span class="dt">string</span>) lens = compose_lens ceo_lens name_lens</span>
+<span id="cb494-16"><a href="#cb494-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb494-17"><a href="#cb494-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> acme = { ceo = alice; founded = <span class="dv">2000</span> }</span>
+<span id="cb494-18"><a href="#cb494-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (ceo_name.get acme = <span class="st">&quot;Alice&quot;</span>)</span>
+<span id="cb494-19"><a href="#cb494-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> acme&#39; = ceo_name.set <span class="st">&quot;Bob&quot;</span> acme</span>
+<span id="cb494-20"><a href="#cb494-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (acme&#39;.ceo.name = <span class="st">&quot;Bob&quot;</span>)</span></code></pre></div>
 <h3 id="why-lenses-go-beyond-zippers">Why Lenses Go Beyond Zippers</h3>
 <p>Zippers work for <em>polynomial</em> types – types built from sums
 and products, where the algebraic derivative is well-defined. But what
@@ -16620,15 +16886,15 @@ about types involving <em>exponentials</em> (function types)?</p>
 Its derivative is not a simple algebraic expression – you cannot “take
 the derivative” of a function type the way you can a product type. Yet a
 lens can still focus on the head:</p>
-<div class="sourceCode" id="cb483"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb483-1"><a href="#cb483-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A stream has no algebraic derivative / concrete zipper, *)</span></span>
-<span id="cb483-2"><a href="#cb483-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* but we can still define lenses on it. *)</span></span>
-<span id="cb483-3"><a href="#cb483-3" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a stream = { head : &#39;a; tail : <span class="dt">unit</span> -&gt; &#39;a stream }</span>
-<span id="cb483-4"><a href="#cb483-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb483-5"><a href="#cb483-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> stream_head_lens = {</span>
-<span id="cb483-6"><a href="#cb483-6" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> s -&gt; s.head);</span>
-<span id="cb483-7"><a href="#cb483-7" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> a s -&gt; { s <span class="kw">with</span> head = a });</span>
-<span id="cb483-8"><a href="#cb483-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb495"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb495-1"><a href="#cb495-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* A stream has no algebraic derivative / concrete zipper, *)</span></span>
+<span id="cb495-2"><a href="#cb495-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* but we can still define lenses on it. *)</span></span>
+<span id="cb495-3"><a href="#cb495-3" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a stream = { head : &#39;a; tail : <span class="dt">unit</span> -&gt; &#39;a stream }</span>
+<span id="cb495-4"><a href="#cb495-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb495-5"><a href="#cb495-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> stream_head_lens = {</span>
+<span id="cb495-6"><a href="#cb495-6" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> s -&gt; s.head);</span>
+<span id="cb495-7"><a href="#cb495-7" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> a s -&gt; { s <span class="kw">with</span> head = a });</span>
+<span id="cb495-8"><a href="#cb495-8" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p>This is the key advantage: lenses abstract over the
 <em>interface</em> to a subpart, regardless of whether the containing
 type has a concrete derivative.</p>
@@ -16638,27 +16904,27 @@ type has a concrete derivative.</p>
 prism for a constructor <code>C</code> of a sum type provides a way to
 try to extract the value (which may fail if the value uses a different
 constructor) and a way to inject a value:</p>
-<div class="sourceCode" id="cb484"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb484-1"><a href="#cb484-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;s, &#39;a) prism = {</span>
-<span id="cb484-2"><a href="#cb484-2" aria-hidden="true" tabindex="-1"></a>  preview : &#39;s -&gt; &#39;a <span class="dt">option</span>;     <span class="co">(* try to extract *)</span></span>
-<span id="cb484-3"><a href="#cb484-3" aria-hidden="true" tabindex="-1"></a>  review  : &#39;a -&gt; &#39;s;            <span class="co">(* inject *)</span></span>
-<span id="cb484-4"><a href="#cb484-4" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb484-5"><a href="#cb484-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb484-6"><a href="#cb484-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* Prism for the Some constructor of option *)</span></span>
-<span id="cb484-7"><a href="#cb484-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> some_prism : (&#39;a <span class="dt">option</span>, &#39;a) prism = {</span>
-<span id="cb484-8"><a href="#cb484-8" aria-hidden="true" tabindex="-1"></a>  preview = <span class="dt">Fun</span>.id;</span>
-<span id="cb484-9"><a href="#cb484-9" aria-hidden="true" tabindex="-1"></a>  review = <span class="dt">Option</span>.some;</span>
-<span id="cb484-10"><a href="#cb484-10" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb484-11"><a href="#cb484-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb484-12"><a href="#cb484-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* Prism for the Ok constructor of result *)</span></span>
-<span id="cb484-13"><a href="#cb484-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> ok_prism : ((&#39;a, &#39;e) <span class="dt">result</span>, &#39;a) prism = {</span>
-<span id="cb484-14"><a href="#cb484-14" aria-hidden="true" tabindex="-1"></a>  preview = Result.to_option;</span>
-<span id="cb484-15"><a href="#cb484-15" aria-hidden="true" tabindex="-1"></a>  review = Result.ok;</span>
-<span id="cb484-16"><a href="#cb484-16" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb484-17"><a href="#cb484-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb484-18"><a href="#cb484-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (some_prism.preview (<span class="dt">Some</span> <span class="dv">42</span>) = <span class="dt">Some</span> <span class="dv">42</span>)</span>
-<span id="cb484-19"><a href="#cb484-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (some_prism.preview <span class="dt">None</span> = <span class="dt">None</span>)</span>
-<span id="cb484-20"><a href="#cb484-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (some_prism.review <span class="dv">42</span> = <span class="dt">Some</span> <span class="dv">42</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb496"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb496-1"><a href="#cb496-1" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;s, &#39;a) prism = {</span>
+<span id="cb496-2"><a href="#cb496-2" aria-hidden="true" tabindex="-1"></a>  preview : &#39;s -&gt; &#39;a <span class="dt">option</span>;     <span class="co">(* try to extract *)</span></span>
+<span id="cb496-3"><a href="#cb496-3" aria-hidden="true" tabindex="-1"></a>  review  : &#39;a -&gt; &#39;s;            <span class="co">(* inject *)</span></span>
+<span id="cb496-4"><a href="#cb496-4" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb496-5"><a href="#cb496-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb496-6"><a href="#cb496-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* Prism for the Some constructor of option *)</span></span>
+<span id="cb496-7"><a href="#cb496-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> some_prism : (&#39;a <span class="dt">option</span>, &#39;a) prism = {</span>
+<span id="cb496-8"><a href="#cb496-8" aria-hidden="true" tabindex="-1"></a>  preview = <span class="dt">Fun</span>.id;</span>
+<span id="cb496-9"><a href="#cb496-9" aria-hidden="true" tabindex="-1"></a>  review = <span class="dt">Option</span>.some;</span>
+<span id="cb496-10"><a href="#cb496-10" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb496-11"><a href="#cb496-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb496-12"><a href="#cb496-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* Prism for the Ok constructor of result *)</span></span>
+<span id="cb496-13"><a href="#cb496-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> ok_prism : ((&#39;a, &#39;e) <span class="dt">result</span>, &#39;a) prism = {</span>
+<span id="cb496-14"><a href="#cb496-14" aria-hidden="true" tabindex="-1"></a>  preview = Result.to_option;</span>
+<span id="cb496-15"><a href="#cb496-15" aria-hidden="true" tabindex="-1"></a>  review = Result.ok;</span>
+<span id="cb496-16"><a href="#cb496-16" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb496-17"><a href="#cb496-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb496-18"><a href="#cb496-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (some_prism.preview (<span class="dt">Some</span> <span class="dv">42</span>) = <span class="dt">Some</span> <span class="dv">42</span>)</span>
+<span id="cb496-19"><a href="#cb496-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (some_prism.preview <span class="dt">None</span> = <span class="dt">None</span>)</span>
+<span id="cb496-20"><a href="#cb496-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (some_prism.review <span class="dv">42</span> = <span class="dt">Some</span> <span class="dv">42</span>)</span></code></pre></div>
 <p>This connects to Chapter 11’s expression problem: you want a
 structure with both good <em>lens access</em> (extending operations on
 products) and good <em>prism access</em> (extending constructors as
@@ -16674,46 +16940,46 @@ discovered by Twan van Laarhoven. A lens from <code>'s</code> to
 why lens libraries are so ergonomic. We will see in Section 12.8 that
 this is an instance of the <em>Yoneda lemma</em>.</p>
 <p>In Haskell, a VL lens is a single rank-2 polymorphic definition:</p>
-<div class="sourceCode" id="cb485"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb485-1"><a href="#cb485-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Haskell-style Van Laarhoven lens (not valid OCaml): *)</span></span>
-<span id="cb485-2"><a href="#cb485-2" aria-hidden="true" tabindex="-1"></a><span class="co">(*   type Lens s a = forall f. Functor f =&gt; (a -&gt; f a) -&gt; s -&gt; f s   *)</span></span>
-<span id="cb485-3"><a href="#cb485-3" aria-hidden="true" tabindex="-1"></a><span class="co">(*   _fst :: Lens (a, b) a                                          *)</span></span>
-<span id="cb485-4"><a href="#cb485-4" aria-hidden="true" tabindex="-1"></a><span class="co">(*   _fst f (x, y) = fmap (\x&#39; -&gt; (x&#39;, y)) (f x)                   *)</span></span>
-<span id="cb485-5"><a href="#cb485-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* Instantiating f = Identity gives &quot;set&quot;; f = Const gives &quot;get&quot;.   *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb497"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb497-1"><a href="#cb497-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Haskell-style Van Laarhoven lens (not valid OCaml): *)</span></span>
+<span id="cb497-2"><a href="#cb497-2" aria-hidden="true" tabindex="-1"></a><span class="co">(*   type Lens s a = forall f. Functor f =&gt; (a -&gt; f a) -&gt; s -&gt; f s   *)</span></span>
+<span id="cb497-3"><a href="#cb497-3" aria-hidden="true" tabindex="-1"></a><span class="co">(*   _fst :: Lens (a, b) a                                          *)</span></span>
+<span id="cb497-4"><a href="#cb497-4" aria-hidden="true" tabindex="-1"></a><span class="co">(*   _fst f (x, y) = fmap (\x&#39; -&gt; (x&#39;, y)) (f x)                   *)</span></span>
+<span id="cb497-5"><a href="#cb497-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* Instantiating f = Identity gives &quot;set&quot;; f = Const gives &quot;get&quot;.   *)</span></span></code></pre></div>
 <p>OCaml lacks higher-rank polymorphism, so a single definition cannot
 quantify over the functor <code>f</code>. We can recover a single lens
 definition by parameterizing over the functor with an OCaml module:</p>
-<div class="sourceCode" id="cb486"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb486-1"><a href="#cb486-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> VL_FUNCTOR = <span class="kw">sig</span></span>
-<span id="cb486-2"><a href="#cb486-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t</span>
-<span id="cb486-3"><a href="#cb486-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> fmap : (&#39;a -&gt; &#39;b) -&gt; &#39;a t -&gt; &#39;b t</span>
-<span id="cb486-4"><a href="#cb486-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb486-5"><a href="#cb486-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb486-6"><a href="#cb486-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* One definition of the lens logic, parameterized by the functor: *)</span></span>
-<span id="cb486-7"><a href="#cb486-7" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> VL_Fst (F : VL_FUNCTOR) = <span class="kw">struct</span></span>
-<span id="cb486-8"><a href="#cb486-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> _fst (f : &#39;a -&gt; &#39;a F.t) (x, y) : (_ * _) F.t =</span>
-<span id="cb486-9"><a href="#cb486-9" aria-hidden="true" tabindex="-1"></a>    F.fmap (<span class="kw">fun</span> x&#39; -&gt; (x&#39;, y)) (f x)</span>
-<span id="cb486-10"><a href="#cb486-10" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb486-11"><a href="#cb486-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb486-12"><a href="#cb486-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* Identity functor -- instantiate for &quot;set&quot;: *)</span></span>
-<span id="cb486-13"><a href="#cb486-13" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> IdF : VL_FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = &#39;a = <span class="kw">struct</span></span>
-<span id="cb486-14"><a href="#cb486-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a</span>
-<span id="cb486-15"><a href="#cb486-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> fmap f x = f x</span>
-<span id="cb486-16"><a href="#cb486-16" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb486-17"><a href="#cb486-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb486-18"><a href="#cb486-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Const functor -- instantiate for &quot;get&quot;: *)</span></span>
-<span id="cb486-19"><a href="#cb486-19" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ConstF (T : <span class="kw">sig</span> <span class="kw">type</span> t <span class="kw">end</span>) :</span>
-<span id="cb486-20"><a href="#cb486-20" aria-hidden="true" tabindex="-1"></a>  VL_FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = T.t =</span>
-<span id="cb486-21"><a href="#cb486-21" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span></span>
-<span id="cb486-22"><a href="#cb486-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = T.t</span>
-<span id="cb486-23"><a href="#cb486-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> fmap _ x = x</span>
-<span id="cb486-24"><a href="#cb486-24" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb486-25"><a href="#cb486-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb486-26"><a href="#cb486-26" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FstSet = VL_Fst(IdF)</span>
-<span id="cb486-27"><a href="#cb486-27" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FstGet = VL_Fst(ConstF(<span class="kw">struct</span> <span class="kw">type</span> t = <span class="dt">int</span> <span class="kw">end</span>))</span>
-<span id="cb486-28"><a href="#cb486-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb486-29"><a href="#cb486-29" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (FstSet._fst (<span class="kw">fun</span> _ -&gt; <span class="dv">10</span>) (<span class="dv">1</span>, <span class="st">&quot;hello&quot;</span>) = (<span class="dv">10</span>, <span class="st">&quot;hello&quot;</span>))</span>
-<span id="cb486-30"><a href="#cb486-30" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (FstGet._fst (<span class="kw">fun</span> a -&gt; a) (<span class="dv">42</span>, <span class="st">&quot;world&quot;</span>) = <span class="dv">42</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb498"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb498-1"><a href="#cb498-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> <span class="kw">type</span> VL_FUNCTOR = <span class="kw">sig</span></span>
+<span id="cb498-2"><a href="#cb498-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t</span>
+<span id="cb498-3"><a href="#cb498-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">val</span> fmap : (&#39;a -&gt; &#39;b) -&gt; &#39;a t -&gt; &#39;b t</span>
+<span id="cb498-4"><a href="#cb498-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb498-5"><a href="#cb498-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb498-6"><a href="#cb498-6" aria-hidden="true" tabindex="-1"></a><span class="co">(* One definition of the lens logic, parameterized by the functor: *)</span></span>
+<span id="cb498-7"><a href="#cb498-7" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> VL_Fst (F : VL_FUNCTOR) = <span class="kw">struct</span></span>
+<span id="cb498-8"><a href="#cb498-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> _fst (f : &#39;a -&gt; &#39;a F.t) (x, y) : (_ * _) F.t =</span>
+<span id="cb498-9"><a href="#cb498-9" aria-hidden="true" tabindex="-1"></a>    F.fmap (<span class="kw">fun</span> x&#39; -&gt; (x&#39;, y)) (f x)</span>
+<span id="cb498-10"><a href="#cb498-10" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb498-11"><a href="#cb498-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb498-12"><a href="#cb498-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* Identity functor -- instantiate for &quot;set&quot;: *)</span></span>
+<span id="cb498-13"><a href="#cb498-13" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> IdF : VL_FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = &#39;a = <span class="kw">struct</span></span>
+<span id="cb498-14"><a href="#cb498-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = &#39;a</span>
+<span id="cb498-15"><a href="#cb498-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> fmap f x = f x</span>
+<span id="cb498-16"><a href="#cb498-16" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb498-17"><a href="#cb498-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb498-18"><a href="#cb498-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Const functor -- instantiate for &quot;get&quot;: *)</span></span>
+<span id="cb498-19"><a href="#cb498-19" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> ConstF (T : <span class="kw">sig</span> <span class="kw">type</span> t <span class="kw">end</span>) :</span>
+<span id="cb498-20"><a href="#cb498-20" aria-hidden="true" tabindex="-1"></a>  VL_FUNCTOR <span class="kw">with</span> <span class="kw">type</span> &#39;a t = T.t =</span>
+<span id="cb498-21"><a href="#cb498-21" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span></span>
+<span id="cb498-22"><a href="#cb498-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> &#39;a t = T.t</span>
+<span id="cb498-23"><a href="#cb498-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> fmap _ x = x</span>
+<span id="cb498-24"><a href="#cb498-24" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb498-25"><a href="#cb498-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb498-26"><a href="#cb498-26" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FstSet = VL_Fst(IdF)</span>
+<span id="cb498-27"><a href="#cb498-27" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> FstGet = VL_Fst(ConstF(<span class="kw">struct</span> <span class="kw">type</span> t = <span class="dt">int</span> <span class="kw">end</span>))</span>
+<span id="cb498-28"><a href="#cb498-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb498-29"><a href="#cb498-29" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (FstSet._fst (<span class="kw">fun</span> _ -&gt; <span class="dv">10</span>) (<span class="dv">1</span>, <span class="st">&quot;hello&quot;</span>) = (<span class="dv">10</span>, <span class="st">&quot;hello&quot;</span>))</span>
+<span id="cb498-30"><a href="#cb498-30" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (FstGet._fst (<span class="kw">fun</span> a -&gt; a) (<span class="dv">42</span>, <span class="st">&quot;world&quot;</span>) = <span class="dv">42</span>)</span></code></pre></div>
 <p>The lens logic lives in a single place – <code>VL_Fst._fst</code> –
 and both get and set are obtained by choosing the functor. The set
 direction (<code>FstSet._fst</code>) is fully polymorphic in the pair
@@ -16736,25 +17002,25 @@ with elements of <span class="math inline">F(A)</span>.</p>
 <p>In programming terms: a polymorphic function
 <code>forall b. (a -&gt; b) -&gt; f b</code> is the same as a value of
 type <code>f a</code>. You can always convert between the two:</p>
-<div class="sourceCode" id="cb487"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb487-1"><a href="#cb487-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The Yoneda lemma in OCaml: *)</span></span>
-<span id="cb487-2"><a href="#cb487-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* A value of type &#39;a F.t is equivalent to *)</span></span>
-<span id="cb487-3"><a href="#cb487-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* a polymorphic function (forall &#39;b. (&#39;a -&gt; &#39;b) -&gt; &#39;b F.t) *)</span></span>
-<span id="cb487-4"><a href="#cb487-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb487-5"><a href="#cb487-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* Forward direction: given f a, produce the natural transformation *)</span></span>
-<span id="cb487-6"><a href="#cb487-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> yoneda_fwd (map : (&#39;a -&gt; &#39;b) -&gt; &#39;a <span class="dt">list</span> -&gt; &#39;b <span class="dt">list</span>)</span>
-<span id="cb487-7"><a href="#cb487-7" aria-hidden="true" tabindex="-1"></a>    (x : &#39;a <span class="dt">list</span>) : (&#39;a -&gt; &#39;b) -&gt; &#39;b <span class="dt">list</span> =</span>
-<span id="cb487-8"><a href="#cb487-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> f -&gt; map f x</span>
-<span id="cb487-9"><a href="#cb487-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb487-10"><a href="#cb487-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Backward direction: given the nat trans, recover f a *)</span></span>
-<span id="cb487-11"><a href="#cb487-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> yoneda_bwd (phi : (&#39;a -&gt; &#39;a) -&gt; &#39;a <span class="dt">list</span>) : &#39;a <span class="dt">list</span> =</span>
-<span id="cb487-12"><a href="#cb487-12" aria-hidden="true" tabindex="-1"></a>  phi <span class="dt">Fun</span>.id    <span class="co">(* apply to the identity! *)</span></span>
-<span id="cb487-13"><a href="#cb487-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb487-14"><a href="#cb487-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Round-trip: *)</span></span>
-<span id="cb487-15"><a href="#cb487-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> original = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>]</span>
-<span id="cb487-16"><a href="#cb487-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> phi = yoneda_fwd <span class="dt">List</span>.map original</span>
-<span id="cb487-17"><a href="#cb487-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> recovered = yoneda_bwd phi</span>
-<span id="cb487-18"><a href="#cb487-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (recovered = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>])</span></code></pre></div>
+<div class="sourceCode" id="cb499"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb499-1"><a href="#cb499-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The Yoneda lemma in OCaml: *)</span></span>
+<span id="cb499-2"><a href="#cb499-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* A value of type &#39;a F.t is equivalent to *)</span></span>
+<span id="cb499-3"><a href="#cb499-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* a polymorphic function (forall &#39;b. (&#39;a -&gt; &#39;b) -&gt; &#39;b F.t) *)</span></span>
+<span id="cb499-4"><a href="#cb499-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb499-5"><a href="#cb499-5" aria-hidden="true" tabindex="-1"></a><span class="co">(* Forward direction: given f a, produce the natural transformation *)</span></span>
+<span id="cb499-6"><a href="#cb499-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> yoneda_fwd (map : (&#39;a -&gt; &#39;b) -&gt; &#39;a <span class="dt">list</span> -&gt; &#39;b <span class="dt">list</span>)</span>
+<span id="cb499-7"><a href="#cb499-7" aria-hidden="true" tabindex="-1"></a>    (x : &#39;a <span class="dt">list</span>) : (&#39;a -&gt; &#39;b) -&gt; &#39;b <span class="dt">list</span> =</span>
+<span id="cb499-8"><a href="#cb499-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> f -&gt; map f x</span>
+<span id="cb499-9"><a href="#cb499-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb499-10"><a href="#cb499-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Backward direction: given the nat trans, recover f a *)</span></span>
+<span id="cb499-11"><a href="#cb499-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> yoneda_bwd (phi : (&#39;a -&gt; &#39;a) -&gt; &#39;a <span class="dt">list</span>) : &#39;a <span class="dt">list</span> =</span>
+<span id="cb499-12"><a href="#cb499-12" aria-hidden="true" tabindex="-1"></a>  phi <span class="dt">Fun</span>.id    <span class="co">(* apply to the identity! *)</span></span>
+<span id="cb499-13"><a href="#cb499-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb499-14"><a href="#cb499-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Round-trip: *)</span></span>
+<span id="cb499-15"><a href="#cb499-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> original = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>]</span>
+<span id="cb499-16"><a href="#cb499-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> phi = yoneda_fwd <span class="dt">List</span>.map original</span>
+<span id="cb499-17"><a href="#cb499-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> recovered = yoneda_bwd phi</span>
+<span id="cb499-18"><a href="#cb499-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (recovered = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>])</span></code></pre></div>
 <h3 id="the-cps-transform">The CPS Transform</h3>
 <p>The most common programming application of Yoneda is the
 <strong>continuation-passing style</strong> (CPS) transform. For the
@@ -16764,36 +17030,36 @@ identity functor, Yoneda gives:</p>
 <p>That is: a value of type <code>'a</code> is the same as a polymorphic
 function <code>forall 'b. ('a -&gt; 'b) -&gt; 'b</code>. This is exactly
 CPS:</p>
-<div class="sourceCode" id="cb488"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb488-1"><a href="#cb488-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* CPS: a value &#39;a ≅ (forall &#39;b. (&#39;a -&gt; &#39;b) -&gt; &#39;b) *)</span></span>
-<span id="cb488-2"><a href="#cb488-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> to_cps (x : &#39;a) : (&#39;a -&gt; &#39;b) -&gt; &#39;b = <span class="kw">fun</span> k -&gt; k x</span>
-<span id="cb488-3"><a href="#cb488-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> from_cps (f : (&#39;a -&gt; &#39;a) -&gt; &#39;a) : &#39;a = f <span class="dt">Fun</span>.id</span>
-<span id="cb488-4"><a href="#cb488-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb488-5"><a href="#cb488-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (from_cps (to_cps <span class="dv">42</span>) = <span class="dv">42</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb500"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb500-1"><a href="#cb500-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* CPS: a value &#39;a ≅ (forall &#39;b. (&#39;a -&gt; &#39;b) -&gt; &#39;b) *)</span></span>
+<span id="cb500-2"><a href="#cb500-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> to_cps (x : &#39;a) : (&#39;a -&gt; &#39;b) -&gt; &#39;b = <span class="kw">fun</span> k -&gt; k x</span>
+<span id="cb500-3"><a href="#cb500-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> from_cps (f : (&#39;a -&gt; &#39;a) -&gt; &#39;a) : &#39;a = f <span class="dt">Fun</span>.id</span>
+<span id="cb500-4"><a href="#cb500-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb500-5"><a href="#cb500-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (from_cps (to_cps <span class="dv">42</span>) = <span class="dv">42</span>)</span></code></pre></div>
 <h3 id="difference-lists">Difference Lists</h3>
 <p>Another Yoneda application: <strong>difference lists</strong>. A list
 <code>xs</code> can be represented as the function
 <code>fun ys -&gt; xs @ ys</code> – that is, as “the operation of
 prepending <code>xs</code>”. This is the Yoneda embedding for the list
 monoid:</p>
-<div class="sourceCode" id="cb489"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb489-1"><a href="#cb489-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Difference lists: represent a list as a function *)</span></span>
-<span id="cb489-2"><a href="#cb489-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a dlist = &#39;a <span class="dt">list</span> -&gt; &#39;a <span class="dt">list</span></span>
-<span id="cb489-3"><a href="#cb489-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb489-4"><a href="#cb489-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_empty : &#39;a dlist = <span class="dt">Fun</span>.id</span>
-<span id="cb489-5"><a href="#cb489-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_singleton (x : &#39;a) : &#39;a dlist = <span class="kw">fun</span> rest -&gt; x :: rest</span>
-<span id="cb489-6"><a href="#cb489-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_append (f : &#39;a dlist) (g : &#39;a dlist) : &#39;a dlist =</span>
-<span id="cb489-7"><a href="#cb489-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> rest -&gt; f (g rest)    <span class="co">(* O(1) append! *)</span></span>
-<span id="cb489-8"><a href="#cb489-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_to_list (f : &#39;a dlist) : &#39;a <span class="dt">list</span> = f []</span>
-<span id="cb489-9"><a href="#cb489-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb489-10"><a href="#cb489-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Building a list incrementally with O(1) append *)</span></span>
-<span id="cb489-11"><a href="#cb489-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="dt">result</span> =</span>
-<span id="cb489-12"><a href="#cb489-12" aria-hidden="true" tabindex="-1"></a>  dlist_append</span>
-<span id="cb489-13"><a href="#cb489-13" aria-hidden="true" tabindex="-1"></a>    (dlist_append (dlist_singleton <span class="dv">1</span>) (dlist_singleton <span class="dv">2</span>))</span>
-<span id="cb489-14"><a href="#cb489-14" aria-hidden="true" tabindex="-1"></a>    (dlist_singleton <span class="dv">3</span>)</span>
-<span id="cb489-15"><a href="#cb489-15" aria-hidden="true" tabindex="-1"></a>  |&gt; dlist_to_list</span>
-<span id="cb489-16"><a href="#cb489-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb489-17"><a href="#cb489-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (<span class="dt">result</span> = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>])</span></code></pre></div>
+<div class="sourceCode" id="cb501"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb501-1"><a href="#cb501-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Difference lists: represent a list as a function *)</span></span>
+<span id="cb501-2"><a href="#cb501-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a dlist = &#39;a <span class="dt">list</span> -&gt; &#39;a <span class="dt">list</span></span>
+<span id="cb501-3"><a href="#cb501-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb501-4"><a href="#cb501-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_empty : &#39;a dlist = <span class="dt">Fun</span>.id</span>
+<span id="cb501-5"><a href="#cb501-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_singleton (x : &#39;a) : &#39;a dlist = <span class="kw">fun</span> rest -&gt; x :: rest</span>
+<span id="cb501-6"><a href="#cb501-6" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_append (f : &#39;a dlist) (g : &#39;a dlist) : &#39;a dlist =</span>
+<span id="cb501-7"><a href="#cb501-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> rest -&gt; f (g rest)    <span class="co">(* O(1) append! *)</span></span>
+<span id="cb501-8"><a href="#cb501-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> dlist_to_list (f : &#39;a dlist) : &#39;a <span class="dt">list</span> = f []</span>
+<span id="cb501-9"><a href="#cb501-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb501-10"><a href="#cb501-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Building a list incrementally with O(1) append *)</span></span>
+<span id="cb501-11"><a href="#cb501-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="dt">result</span> =</span>
+<span id="cb501-12"><a href="#cb501-12" aria-hidden="true" tabindex="-1"></a>  dlist_append</span>
+<span id="cb501-13"><a href="#cb501-13" aria-hidden="true" tabindex="-1"></a>    (dlist_append (dlist_singleton <span class="dv">1</span>) (dlist_singleton <span class="dv">2</span>))</span>
+<span id="cb501-14"><a href="#cb501-14" aria-hidden="true" tabindex="-1"></a>    (dlist_singleton <span class="dv">3</span>)</span>
+<span id="cb501-15"><a href="#cb501-15" aria-hidden="true" tabindex="-1"></a>  |&gt; dlist_to_list</span>
+<span id="cb501-16"><a href="#cb501-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb501-17"><a href="#cb501-17" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (<span class="dt">result</span> = [<span class="dv">1</span>; <span class="dv">2</span>; <span class="dv">3</span>])</span></code></pre></div>
 <p>Difference lists turn <span class="math inline">O(n)</span> append
 into <span class="math inline">O(1)</span> by delaying the actual
 construction. The Yoneda lemma guarantees no information is lost.</p>
@@ -16803,32 +17069,32 @@ monad</strong>: given a monad <span class="math inline">M</span>, the
 type <code>forall b. (a -&gt; m b) -&gt; m b</code> is a monad (the
 “Codensity monad of <span class="math inline">M</span>”) that often has
 better performance for left-associated binds:</p>
-<div class="sourceCode" id="cb490"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb490-1"><a href="#cb490-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The Codensity monad improves left-associated binds *)</span></span>
-<span id="cb490-2"><a href="#cb490-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Codensity M a = forall b. (a -&gt; M b) -&gt; M b *)</span></span>
-<span id="cb490-3"><a href="#cb490-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb490-4"><a href="#cb490-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* For lists, Codensity gives efficient left-to-right construction *)</span></span>
-<span id="cb490-5"><a href="#cb490-5" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a clist = { run : &#39;b. (&#39;a -&gt; &#39;b <span class="dt">list</span>) -&gt; &#39;b <span class="dt">list</span> }</span>
-<span id="cb490-6"><a href="#cb490-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb490-7"><a href="#cb490-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> creturn (x : &#39;a) : &#39;a clist =</span>
-<span id="cb490-8"><a href="#cb490-8" aria-hidden="true" tabindex="-1"></a>  { run = <span class="kw">fun</span> k -&gt; k x }</span>
-<span id="cb490-9"><a href="#cb490-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb490-10"><a href="#cb490-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> cbind (m : &#39;a clist) (f : &#39;a -&gt; &#39;b clist) : &#39;b clist =</span>
-<span id="cb490-11"><a href="#cb490-11" aria-hidden="true" tabindex="-1"></a>  { run = <span class="kw">fun</span> k -&gt; m.run (<span class="kw">fun</span> a -&gt; (f a).run k) }</span>
-<span id="cb490-12"><a href="#cb490-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb490-13"><a href="#cb490-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> clift (xs : &#39;a <span class="dt">list</span>) : &#39;a clist =</span>
-<span id="cb490-14"><a href="#cb490-14" aria-hidden="true" tabindex="-1"></a>  { run = <span class="kw">fun</span> k -&gt; <span class="dt">List</span>.concat_map k xs }</span>
-<span id="cb490-15"><a href="#cb490-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb490-16"><a href="#cb490-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> crun (m : &#39;a clist) : &#39;a <span class="dt">list</span> = m.run (<span class="kw">fun</span> x -&gt; [x])</span>
-<span id="cb490-17"><a href="#cb490-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb490-18"><a href="#cb490-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: all pairs from two lists *)</span></span>
-<span id="cb490-19"><a href="#cb490-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> pairs xs ys =</span>
-<span id="cb490-20"><a href="#cb490-20" aria-hidden="true" tabindex="-1"></a>  crun (cbind (clift xs) (<span class="kw">fun</span> x -&gt;</span>
-<span id="cb490-21"><a href="#cb490-21" aria-hidden="true" tabindex="-1"></a>        cbind (clift ys) (<span class="kw">fun</span> y -&gt;</span>
-<span id="cb490-22"><a href="#cb490-22" aria-hidden="true" tabindex="-1"></a>        creturn (x, y))))</span>
-<span id="cb490-23"><a href="#cb490-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb490-24"><a href="#cb490-24" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (pairs [<span class="dv">1</span>;<span class="dv">2</span>] [<span class="st">&quot;a&quot;</span>;<span class="st">&quot;b&quot;</span>]</span>
-<span id="cb490-25"><a href="#cb490-25" aria-hidden="true" tabindex="-1"></a>               = [(<span class="dv">1</span>,<span class="st">&quot;a&quot;</span>); (<span class="dv">1</span>,<span class="st">&quot;b&quot;</span>); (<span class="dv">2</span>,<span class="st">&quot;a&quot;</span>); (<span class="dv">2</span>,<span class="st">&quot;b&quot;</span>)])</span></code></pre></div>
+<div class="sourceCode" id="cb502"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb502-1"><a href="#cb502-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* The Codensity monad improves left-associated binds *)</span></span>
+<span id="cb502-2"><a href="#cb502-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* Codensity M a = forall b. (a -&gt; M b) -&gt; M b *)</span></span>
+<span id="cb502-3"><a href="#cb502-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb502-4"><a href="#cb502-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* For lists, Codensity gives efficient left-to-right construction *)</span></span>
+<span id="cb502-5"><a href="#cb502-5" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a clist = { run : &#39;b. (&#39;a -&gt; &#39;b <span class="dt">list</span>) -&gt; &#39;b <span class="dt">list</span> }</span>
+<span id="cb502-6"><a href="#cb502-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb502-7"><a href="#cb502-7" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> creturn (x : &#39;a) : &#39;a clist =</span>
+<span id="cb502-8"><a href="#cb502-8" aria-hidden="true" tabindex="-1"></a>  { run = <span class="kw">fun</span> k -&gt; k x }</span>
+<span id="cb502-9"><a href="#cb502-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb502-10"><a href="#cb502-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> cbind (m : &#39;a clist) (f : &#39;a -&gt; &#39;b clist) : &#39;b clist =</span>
+<span id="cb502-11"><a href="#cb502-11" aria-hidden="true" tabindex="-1"></a>  { run = <span class="kw">fun</span> k -&gt; m.run (<span class="kw">fun</span> a -&gt; (f a).run k) }</span>
+<span id="cb502-12"><a href="#cb502-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb502-13"><a href="#cb502-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> clift (xs : &#39;a <span class="dt">list</span>) : &#39;a clist =</span>
+<span id="cb502-14"><a href="#cb502-14" aria-hidden="true" tabindex="-1"></a>  { run = <span class="kw">fun</span> k -&gt; <span class="dt">List</span>.concat_map k xs }</span>
+<span id="cb502-15"><a href="#cb502-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb502-16"><a href="#cb502-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> crun (m : &#39;a clist) : &#39;a <span class="dt">list</span> = m.run (<span class="kw">fun</span> x -&gt; [x])</span>
+<span id="cb502-17"><a href="#cb502-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb502-18"><a href="#cb502-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Example: all pairs from two lists *)</span></span>
+<span id="cb502-19"><a href="#cb502-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> pairs xs ys =</span>
+<span id="cb502-20"><a href="#cb502-20" aria-hidden="true" tabindex="-1"></a>  crun (cbind (clift xs) (<span class="kw">fun</span> x -&gt;</span>
+<span id="cb502-21"><a href="#cb502-21" aria-hidden="true" tabindex="-1"></a>        cbind (clift ys) (<span class="kw">fun</span> y -&gt;</span>
+<span id="cb502-22"><a href="#cb502-22" aria-hidden="true" tabindex="-1"></a>        creturn (x, y))))</span>
+<span id="cb502-23"><a href="#cb502-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb502-24"><a href="#cb502-24" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (pairs [<span class="dv">1</span>;<span class="dv">2</span>] [<span class="st">&quot;a&quot;</span>;<span class="st">&quot;b&quot;</span>]</span>
+<span id="cb502-25"><a href="#cb502-25" aria-hidden="true" tabindex="-1"></a>               = [(<span class="dv">1</span>,<span class="st">&quot;a&quot;</span>); (<span class="dv">1</span>,<span class="st">&quot;b&quot;</span>); (<span class="dv">2</span>,<span class="st">&quot;a&quot;</span>); (<span class="dv">2</span>,<span class="st">&quot;b&quot;</span>)])</span></code></pre></div>
 <p>The deep insight: every object in a category is completely determined
 by how other objects map <em>into</em> it. The representable functors
 <span class="math inline">\text{Hom}(A, -)</span> form a “coordinate
@@ -16876,37 +17142,37 @@ Transformations</h3>
 the type index</em> – it must work uniformly for any extension of the
 base type. This is exactly the requirement that the operation be a
 <strong>natural transformation</strong>:</p>
-<div class="sourceCode" id="cb491"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb491-1"><a href="#cb491-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Each eval function has a type like: *)</span></span>
-<span id="cb491-2"><a href="#cb491-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* val eval : [&gt; `Var of string | `Num of int ] -&gt; value *)</span></span>
-<span id="cb491-3"><a href="#cb491-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* The [&gt; ...] means it works for any extension -- *)</span></span>
-<span id="cb491-4"><a href="#cb491-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* this is naturality in the row variable. *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb503"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb503-1"><a href="#cb503-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Each eval function has a type like: *)</span></span>
+<span id="cb503-2"><a href="#cb503-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* val eval : [&gt; `Var of string | `Num of int ] -&gt; value *)</span></span>
+<span id="cb503-3"><a href="#cb503-3" aria-hidden="true" tabindex="-1"></a><span class="co">(* The [&gt; ...] means it works for any extension -- *)</span></span>
+<span id="cb503-4"><a href="#cb503-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* this is naturality in the row variable. *)</span></span></code></pre></div>
 <p>We can see the naturality square in action with polymorphic variants.
 Base operations are reused unchanged when the type is extended:</p>
-<div class="sourceCode" id="cb492"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb492-1"><a href="#cb492-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Base language with eval and show: *)</span></span>
-<span id="cb492-2"><a href="#cb492-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> eval_base = <span class="kw">function</span> `Num n -&gt; n | `Neg n -&gt; -n</span>
-<span id="cb492-3"><a href="#cb492-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> show_base = <span class="kw">function</span></span>
-<span id="cb492-4"><a href="#cb492-4" aria-hidden="true" tabindex="-1"></a>  | `Num n -&gt; <span class="dt">string_of_int</span> n</span>
-<span id="cb492-5"><a href="#cb492-5" aria-hidden="true" tabindex="-1"></a>  | `Neg n -&gt; <span class="st">&quot;-&quot;</span> ^ <span class="dt">string_of_int</span> n</span>
-<span id="cb492-6"><a href="#cb492-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb492-7"><a href="#cb492-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* Extended language -- base cases reuse the base operations: *)</span></span>
-<span id="cb492-8"><a href="#cb492-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> eval_ext = <span class="kw">function</span></span>
-<span id="cb492-9"><a href="#cb492-9" aria-hidden="true" tabindex="-1"></a>  | (`Num _ | `Neg _) <span class="kw">as</span> e -&gt; eval_base e    <span class="co">(* reuse *)</span></span>
-<span id="cb492-10"><a href="#cb492-10" aria-hidden="true" tabindex="-1"></a>  | `Add (a, b) -&gt; a + b</span>
-<span id="cb492-11"><a href="#cb492-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> show_ext = <span class="kw">function</span></span>
-<span id="cb492-12"><a href="#cb492-12" aria-hidden="true" tabindex="-1"></a>  | (`Num _ | `Neg _) <span class="kw">as</span> e -&gt; show_base e    <span class="co">(* reuse *)</span></span>
-<span id="cb492-13"><a href="#cb492-13" aria-hidden="true" tabindex="-1"></a>  | `Add (a, b) -&gt; <span class="dt">string_of_int</span> a ^ <span class="st">&quot;+&quot;</span> ^ <span class="dt">string_of_int</span> b</span>
-<span id="cb492-14"><a href="#cb492-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb492-15"><a href="#cb492-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* The naturality square commutes: embedding a base expression *)</span></span>
-<span id="cb492-16"><a href="#cb492-16" aria-hidden="true" tabindex="-1"></a><span class="co">(* into the extended type and then evaluating gives the same   *)</span></span>
-<span id="cb492-17"><a href="#cb492-17" aria-hidden="true" tabindex="-1"></a><span class="co">(* result as evaluating in the base language directly.         *)</span></span>
-<span id="cb492-18"><a href="#cb492-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> e1 = `Num <span class="dv">5</span></span>
-<span id="cb492-19"><a href="#cb492-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> e2 = `Neg <span class="dv">3</span></span>
-<span id="cb492-20"><a href="#cb492-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (eval_ext e1 = eval_base e1)</span>
-<span id="cb492-21"><a href="#cb492-21" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (eval_ext e2 = eval_base e2)</span>
-<span id="cb492-22"><a href="#cb492-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (show_ext e1 = show_base e1)</span>
-<span id="cb492-23"><a href="#cb492-23" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (show_ext e2 = show_base e2)</span></code></pre></div>
+<div class="sourceCode" id="cb504"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb504-1"><a href="#cb504-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Base language with eval and show: *)</span></span>
+<span id="cb504-2"><a href="#cb504-2" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> eval_base = <span class="kw">function</span> `Num n -&gt; n | `Neg n -&gt; -n</span>
+<span id="cb504-3"><a href="#cb504-3" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> show_base = <span class="kw">function</span></span>
+<span id="cb504-4"><a href="#cb504-4" aria-hidden="true" tabindex="-1"></a>  | `Num n -&gt; <span class="dt">string_of_int</span> n</span>
+<span id="cb504-5"><a href="#cb504-5" aria-hidden="true" tabindex="-1"></a>  | `Neg n -&gt; <span class="st">&quot;-&quot;</span> ^ <span class="dt">string_of_int</span> n</span>
+<span id="cb504-6"><a href="#cb504-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb504-7"><a href="#cb504-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* Extended language -- base cases reuse the base operations: *)</span></span>
+<span id="cb504-8"><a href="#cb504-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> eval_ext = <span class="kw">function</span></span>
+<span id="cb504-9"><a href="#cb504-9" aria-hidden="true" tabindex="-1"></a>  | (`Num _ | `Neg _) <span class="kw">as</span> e -&gt; eval_base e    <span class="co">(* reuse *)</span></span>
+<span id="cb504-10"><a href="#cb504-10" aria-hidden="true" tabindex="-1"></a>  | `Add (a, b) -&gt; a + b</span>
+<span id="cb504-11"><a href="#cb504-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> show_ext = <span class="kw">function</span></span>
+<span id="cb504-12"><a href="#cb504-12" aria-hidden="true" tabindex="-1"></a>  | (`Num _ | `Neg _) <span class="kw">as</span> e -&gt; show_base e    <span class="co">(* reuse *)</span></span>
+<span id="cb504-13"><a href="#cb504-13" aria-hidden="true" tabindex="-1"></a>  | `Add (a, b) -&gt; <span class="dt">string_of_int</span> a ^ <span class="st">&quot;+&quot;</span> ^ <span class="dt">string_of_int</span> b</span>
+<span id="cb504-14"><a href="#cb504-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb504-15"><a href="#cb504-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* The naturality square commutes: embedding a base expression *)</span></span>
+<span id="cb504-16"><a href="#cb504-16" aria-hidden="true" tabindex="-1"></a><span class="co">(* into the extended type and then evaluating gives the same   *)</span></span>
+<span id="cb504-17"><a href="#cb504-17" aria-hidden="true" tabindex="-1"></a><span class="co">(* result as evaluating in the base language directly.         *)</span></span>
+<span id="cb504-18"><a href="#cb504-18" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> e1 = `Num <span class="dv">5</span></span>
+<span id="cb504-19"><a href="#cb504-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> e2 = `Neg <span class="dv">3</span></span>
+<span id="cb504-20"><a href="#cb504-20" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (eval_ext e1 = eval_base e1)</span>
+<span id="cb504-21"><a href="#cb504-21" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (eval_ext e2 = eval_base e2)</span>
+<span id="cb504-22"><a href="#cb504-22" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (show_ext e1 = show_base e1)</span>
+<span id="cb504-23"><a href="#cb504-23" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (show_ext e2 = show_base e2)</span></code></pre></div>
 <p>The dynamic failure when no handler covers a constructor (e.g., in
 the extensible GADT approach from the OCaml discussion thread) is the
 <em>colimit not existing</em>: we tried to form a coproduct of partial
@@ -17008,26 +17274,26 @@ class="math inline">A \wedge B \Rightarrow B \wedge A</span></li>
 <li><strong>Constructing</strong> a morphism <span class="math inline">A
 \times B \to B \times A</span> in a CCC</li>
 </ul>
-<div class="sourceCode" id="cb493"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb493-1"><a href="#cb493-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Programs that are simultaneously logical proofs *)</span></span>
-<span id="cb493-2"><a href="#cb493-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* and morphisms in a cartesian closed category:   *)</span></span>
-<span id="cb493-3"><a href="#cb493-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb493-4"><a href="#cb493-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* A ∧ B ⊃ B ∧ A  (commutativity of conjunction) *)</span></span>
-<span id="cb493-5"><a href="#cb493-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> comm : &#39;a * &#39;b -&gt; &#39;b * &#39;a = <span class="kw">fun</span> (x, y) -&gt; (y, x)</span>
-<span id="cb493-6"><a href="#cb493-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb493-7"><a href="#cb493-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* A ⊃ B ⊃ A  (weakening / the K combinator) *)</span></span>
-<span id="cb493-8"><a href="#cb493-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> weaken : &#39;a -&gt; &#39;b -&gt; &#39;a = <span class="kw">fun</span> a _b -&gt; a</span>
-<span id="cb493-9"><a href="#cb493-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb493-10"><a href="#cb493-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* (A ⊃ B ⊃ C) ⊃ (A ∧ B ⊃ C)  (flip of currying) *)</span></span>
-<span id="cb493-11"><a href="#cb493-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> uncurry&#39; : (&#39;a -&gt; &#39;b -&gt; &#39;c) -&gt; &#39;a * &#39;b -&gt; &#39;c =</span>
-<span id="cb493-12"><a href="#cb493-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> f (a, b) -&gt; f a b</span>
-<span id="cb493-13"><a href="#cb493-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb493-14"><a href="#cb493-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* (A ⊃ B) ⊃ (B ⊃ C) ⊃ (A ⊃ C)  (transitivity = composition) *)</span></span>
-<span id="cb493-15"><a href="#cb493-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> trans : (&#39;a -&gt; &#39;b) -&gt; (&#39;b -&gt; &#39;c) -&gt; &#39;a -&gt; &#39;c =</span>
-<span id="cb493-16"><a href="#cb493-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> ab bc a -&gt; bc (ab a)</span>
-<span id="cb493-17"><a href="#cb493-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb493-18"><a href="#cb493-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* trans is compose with arguments reordered: *)</span></span>
-<span id="cb493-19"><a href="#cb493-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (trans f g <span class="dv">3</span> = compose g f <span class="dv">3</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb505"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb505-1"><a href="#cb505-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Programs that are simultaneously logical proofs *)</span></span>
+<span id="cb505-2"><a href="#cb505-2" aria-hidden="true" tabindex="-1"></a><span class="co">(* and morphisms in a cartesian closed category:   *)</span></span>
+<span id="cb505-3"><a href="#cb505-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb505-4"><a href="#cb505-4" aria-hidden="true" tabindex="-1"></a><span class="co">(* A ∧ B ⊃ B ∧ A  (commutativity of conjunction) *)</span></span>
+<span id="cb505-5"><a href="#cb505-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> comm : &#39;a * &#39;b -&gt; &#39;b * &#39;a = <span class="kw">fun</span> (x, y) -&gt; (y, x)</span>
+<span id="cb505-6"><a href="#cb505-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb505-7"><a href="#cb505-7" aria-hidden="true" tabindex="-1"></a><span class="co">(* A ⊃ B ⊃ A  (weakening / the K combinator) *)</span></span>
+<span id="cb505-8"><a href="#cb505-8" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> weaken : &#39;a -&gt; &#39;b -&gt; &#39;a = <span class="kw">fun</span> a _b -&gt; a</span>
+<span id="cb505-9"><a href="#cb505-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb505-10"><a href="#cb505-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* (A ⊃ B ⊃ C) ⊃ (A ∧ B ⊃ C)  (flip of currying) *)</span></span>
+<span id="cb505-11"><a href="#cb505-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> uncurry&#39; : (&#39;a -&gt; &#39;b -&gt; &#39;c) -&gt; &#39;a * &#39;b -&gt; &#39;c =</span>
+<span id="cb505-12"><a href="#cb505-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> f (a, b) -&gt; f a b</span>
+<span id="cb505-13"><a href="#cb505-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb505-14"><a href="#cb505-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* (A ⊃ B) ⊃ (B ⊃ C) ⊃ (A ⊃ C)  (transitivity = composition) *)</span></span>
+<span id="cb505-15"><a href="#cb505-15" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> trans : (&#39;a -&gt; &#39;b) -&gt; (&#39;b -&gt; &#39;c) -&gt; &#39;a -&gt; &#39;c =</span>
+<span id="cb505-16"><a href="#cb505-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">fun</span> ab bc a -&gt; bc (ab a)</span>
+<span id="cb505-17"><a href="#cb505-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb505-18"><a href="#cb505-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* trans is compose with arguments reordered: *)</span></span>
+<span id="cb505-19"><a href="#cb505-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> () = <span class="kw">assert</span> (trans f g <span class="dv">3</span> = compose g f <span class="dv">3</span>)</span></code></pre></div>
 <h3 id="negation-and-continuations">Negation and Continuations</h3>
 <p>Classical logic allows double negation elimination: <span
 class="math inline">\neg\neg A \Rightarrow A</span>. In the Curry–Howard
@@ -17081,23 +17347,23 @@ category of <code>Option</code>). Implement <code>id</code> and
 <code>compose</code>, and verify the three category laws on test cases.
 (Hint: this is the composition you get from
 <code>Option.bind</code>.)</p>
-<div class="sourceCode" id="cb494"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb494-1"><a href="#cb494-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 1 *)</span></span>
-<span id="cb494-2"><a href="#cb494-2" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> KleisliOption <span class="co">(* : CATEGORY ... *)</span> = <span class="kw">struct</span></span>
-<span id="cb494-3"><a href="#cb494-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b <span class="dt">option</span></span>
-<span id="cb494-4"><a href="#cb494-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> id x = <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
-<span id="cb494-5"><a href="#cb494-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> compose g f x = <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
-<span id="cb494-6"><a href="#cb494-6" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
-<span id="cb494-7"><a href="#cb494-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb494-8"><a href="#cb494-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Test the laws with these morphisms: *)</span></span>
-<span id="cb494-9"><a href="#cb494-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = <span class="kw">if</span> x &gt; <span class="dv">0</span> <span class="kw">then</span> <span class="dt">Some</span> (x + <span class="dv">1</span>) <span class="kw">else</span> <span class="dt">None</span></span>
-<span id="cb494-10"><a href="#cb494-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = <span class="kw">if</span> x &lt; <span class="dv">100</span> <span class="kw">then</span> <span class="dt">Some</span> (x * <span class="dv">2</span>) <span class="kw">else</span> <span class="dt">None</span></span>
-<span id="cb494-11"><a href="#cb494-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> x = <span class="dv">5</span></span>
-<span id="cb494-12"><a href="#cb494-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb494-13"><a href="#cb494-13" aria-hidden="true" tabindex="-1"></a><span class="co">(* Left identity:  compose id f x = f x *)</span></span>
-<span id="cb494-14"><a href="#cb494-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Right identity: compose f id x = f x *)</span></span>
-<span id="cb494-15"><a href="#cb494-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Associativity:  compose h (compose g f) x</span></span>
-<span id="cb494-16"><a href="#cb494-16" aria-hidden="true" tabindex="-1"></a><span class="co">                 = compose (compose h g) f x *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb506"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb506-1"><a href="#cb506-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 1 *)</span></span>
+<span id="cb506-2"><a href="#cb506-2" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> KleisliOption <span class="co">(* : CATEGORY ... *)</span> = <span class="kw">struct</span></span>
+<span id="cb506-3"><a href="#cb506-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> (&#39;a, &#39;b) hom = &#39;a -&gt; &#39;b <span class="dt">option</span></span>
+<span id="cb506-4"><a href="#cb506-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> id x = <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
+<span id="cb506-5"><a href="#cb506-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span> compose g f x = <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
+<span id="cb506-6"><a href="#cb506-6" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb506-7"><a href="#cb506-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb506-8"><a href="#cb506-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Test the laws with these morphisms: *)</span></span>
+<span id="cb506-9"><a href="#cb506-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = <span class="kw">if</span> x &gt; <span class="dv">0</span> <span class="kw">then</span> <span class="dt">Some</span> (x + <span class="dv">1</span>) <span class="kw">else</span> <span class="dt">None</span></span>
+<span id="cb506-10"><a href="#cb506-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = <span class="kw">if</span> x &lt; <span class="dv">100</span> <span class="kw">then</span> <span class="dt">Some</span> (x * <span class="dv">2</span>) <span class="kw">else</span> <span class="dt">None</span></span>
+<span id="cb506-11"><a href="#cb506-11" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> x = <span class="dv">5</span></span>
+<span id="cb506-12"><a href="#cb506-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb506-13"><a href="#cb506-13" aria-hidden="true" tabindex="-1"></a><span class="co">(* Left identity:  compose id f x = f x *)</span></span>
+<span id="cb506-14"><a href="#cb506-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Right identity: compose f id x = f x *)</span></span>
+<span id="cb506-15"><a href="#cb506-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Associativity:  compose h (compose g f) x</span></span>
+<span id="cb506-16"><a href="#cb506-16" aria-hidden="true" tabindex="-1"></a><span class="co">                 = compose (compose h g) f x *)</span></span></code></pre></div>
 <h3 id="exercise-2-free-category">Exercise 2: Free category</h3>
 <p>Extend the pipeline example from Section 12.3 with two new stages
 (e.g., <code>Uppercase : (string, string) stage</code> and
@@ -17105,47 +17371,47 @@ class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb494-1"><a hr
 through the graph and interpret each one. Verify that
 <code>concat</code> is associative:
 <code>interpret (concat (concat p q) r) x = interpret (concat p (concat q r)) x</code>.</p>
-<div class="sourceCode" id="cb495"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb495-1"><a href="#cb495-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 2 *)</span></span>
-<span id="cb495-2"><a href="#cb495-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;a, &#39;b) stage =</span>
-<span id="cb495-3"><a href="#cb495-3" aria-hidden="true" tabindex="-1"></a>  | Parse     : (<span class="dt">string</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
-<span id="cb495-4"><a href="#cb495-4" aria-hidden="true" tabindex="-1"></a>  | Filter    : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
-<span id="cb495-5"><a href="#cb495-5" aria-hidden="true" tabindex="-1"></a>  | Count     : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">int</span>) stage</span>
-<span id="cb495-6"><a href="#cb495-6" aria-hidden="true" tabindex="-1"></a>  | Show      : (<span class="dt">int</span>, <span class="dt">string</span>) stage</span>
-<span id="cb495-7"><a href="#cb495-7" aria-hidden="true" tabindex="-1"></a>  | Uppercase : (<span class="dt">string</span>, <span class="dt">string</span>) stage      <span class="co">(* new *)</span></span>
-<span id="cb495-8"><a href="#cb495-8" aria-hidden="true" tabindex="-1"></a>  | Length    : (<span class="dt">string</span>, <span class="dt">int</span>) stage          <span class="co">(* new *)</span></span>
-<span id="cb495-9"><a href="#cb495-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb495-10"><a href="#cb495-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Copy the path type, concat, interpret_stage, and interpret *)</span></span>
-<span id="cb495-11"><a href="#cb495-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* from Section 12.3, then extend interpret_stage for the     *)</span></span>
-<span id="cb495-12"><a href="#cb495-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* new constructors.                                          *)</span></span>
-<span id="cb495-13"><a href="#cb495-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb495-14"><a href="#cb495-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Build three distinct paths and verify: *)</span></span>
-<span id="cb495-15"><a href="#cb495-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* interpret (concat (concat p q) r) x                       *)</span></span>
-<span id="cb495-16"><a href="#cb495-16" aria-hidden="true" tabindex="-1"></a><span class="co">(*   = interpret (concat p (concat q r)) x                   *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb507"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb507-1"><a href="#cb507-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 2 *)</span></span>
+<span id="cb507-2"><a href="#cb507-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> (&#39;a, &#39;b) stage =</span>
+<span id="cb507-3"><a href="#cb507-3" aria-hidden="true" tabindex="-1"></a>  | Parse     : (<span class="dt">string</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
+<span id="cb507-4"><a href="#cb507-4" aria-hidden="true" tabindex="-1"></a>  | Filter    : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">string</span> <span class="dt">list</span>) stage</span>
+<span id="cb507-5"><a href="#cb507-5" aria-hidden="true" tabindex="-1"></a>  | Count     : (<span class="dt">string</span> <span class="dt">list</span>, <span class="dt">int</span>) stage</span>
+<span id="cb507-6"><a href="#cb507-6" aria-hidden="true" tabindex="-1"></a>  | Show      : (<span class="dt">int</span>, <span class="dt">string</span>) stage</span>
+<span id="cb507-7"><a href="#cb507-7" aria-hidden="true" tabindex="-1"></a>  | Uppercase : (<span class="dt">string</span>, <span class="dt">string</span>) stage      <span class="co">(* new *)</span></span>
+<span id="cb507-8"><a href="#cb507-8" aria-hidden="true" tabindex="-1"></a>  | Length    : (<span class="dt">string</span>, <span class="dt">int</span>) stage          <span class="co">(* new *)</span></span>
+<span id="cb507-9"><a href="#cb507-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb507-10"><a href="#cb507-10" aria-hidden="true" tabindex="-1"></a><span class="co">(* Copy the path type, concat, interpret_stage, and interpret *)</span></span>
+<span id="cb507-11"><a href="#cb507-11" aria-hidden="true" tabindex="-1"></a><span class="co">(* from Section 12.3, then extend interpret_stage for the     *)</span></span>
+<span id="cb507-12"><a href="#cb507-12" aria-hidden="true" tabindex="-1"></a><span class="co">(* new constructors.                                          *)</span></span>
+<span id="cb507-13"><a href="#cb507-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb507-14"><a href="#cb507-14" aria-hidden="true" tabindex="-1"></a><span class="co">(* Build three distinct paths and verify: *)</span></span>
+<span id="cb507-15"><a href="#cb507-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* interpret (concat (concat p q) r) x                       *)</span></span>
+<span id="cb507-16"><a href="#cb507-16" aria-hidden="true" tabindex="-1"></a><span class="co">(*   = interpret (concat p (concat q r)) x                   *)</span></span></code></pre></div>
 <h3 id="exercise-3-functor-laws">Exercise 3: Functor laws</h3>
 <p>Write a functor instance for
 <code>type 'a tree = Leaf | Node of 'a tree * 'a * 'a tree</code> and
 test the functor laws (<code>map id = id</code> and
 <code>map (f ∘ g) = map f ∘ map g</code>) on at least two non-trivial
 trees.</p>
-<div class="sourceCode" id="cb496"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb496-1"><a href="#cb496-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 3 *)</span></span>
-<span id="cb496-2"><a href="#cb496-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a tree = Leaf | Node <span class="kw">of</span> &#39;a tree * &#39;a * &#39;a tree</span>
-<span id="cb496-3"><a href="#cb496-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb496-4"><a href="#cb496-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> map_tree (f : &#39;a -&gt; &#39;b) : &#39;a tree -&gt; &#39;b tree = <span class="kw">function</span></span>
-<span id="cb496-5"><a href="#cb496-5" aria-hidden="true" tabindex="-1"></a>  | Leaf -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
-<span id="cb496-6"><a href="#cb496-6" aria-hidden="true" tabindex="-1"></a>  | Node (l, v, r) -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
-<span id="cb496-7"><a href="#cb496-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb496-8"><a href="#cb496-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Test trees: *)</span></span>
-<span id="cb496-9"><a href="#cb496-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> t1 = Node (Node (Leaf, <span class="dv">1</span>, Leaf), <span class="dv">2</span>, Node (Leaf, <span class="dv">3</span>, Leaf))</span>
-<span id="cb496-10"><a href="#cb496-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> t2 = Node (Leaf, <span class="dv">10</span>, Node (Node (Leaf, <span class="dv">20</span>, Leaf), <span class="dv">30</span>, Leaf))</span>
-<span id="cb496-11"><a href="#cb496-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb496-12"><a href="#cb496-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x + <span class="dv">1</span></span>
-<span id="cb496-13"><a href="#cb496-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = x * <span class="dv">2</span></span>
-<span id="cb496-14"><a href="#cb496-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb496-15"><a href="#cb496-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Law 1: map_tree Fun.id t = t *)</span></span>
-<span id="cb496-16"><a href="#cb496-16" aria-hidden="true" tabindex="-1"></a><span class="co">(* Law 2: map_tree (fun x -&gt; f (g x)) t *)</span></span>
-<span id="cb496-17"><a href="#cb496-17" aria-hidden="true" tabindex="-1"></a><span class="co">(*      = map_tree f (map_tree g t)      *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb508"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb508-1"><a href="#cb508-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 3 *)</span></span>
+<span id="cb508-2"><a href="#cb508-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> &#39;a tree = Leaf | Node <span class="kw">of</span> &#39;a tree * &#39;a * &#39;a tree</span>
+<span id="cb508-3"><a href="#cb508-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb508-4"><a href="#cb508-4" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> <span class="kw">rec</span> map_tree (f : &#39;a -&gt; &#39;b) : &#39;a tree -&gt; &#39;b tree = <span class="kw">function</span></span>
+<span id="cb508-5"><a href="#cb508-5" aria-hidden="true" tabindex="-1"></a>  | Leaf -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
+<span id="cb508-6"><a href="#cb508-6" aria-hidden="true" tabindex="-1"></a>  | Node (l, v, r) -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span></span>
+<span id="cb508-7"><a href="#cb508-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb508-8"><a href="#cb508-8" aria-hidden="true" tabindex="-1"></a><span class="co">(* Test trees: *)</span></span>
+<span id="cb508-9"><a href="#cb508-9" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> t1 = Node (Node (Leaf, <span class="dv">1</span>, Leaf), <span class="dv">2</span>, Node (Leaf, <span class="dv">3</span>, Leaf))</span>
+<span id="cb508-10"><a href="#cb508-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> t2 = Node (Leaf, <span class="dv">10</span>, Node (Node (Leaf, <span class="dv">20</span>, Leaf), <span class="dv">30</span>, Leaf))</span>
+<span id="cb508-11"><a href="#cb508-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb508-12"><a href="#cb508-12" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> f x = x + <span class="dv">1</span></span>
+<span id="cb508-13"><a href="#cb508-13" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> g x = x * <span class="dv">2</span></span>
+<span id="cb508-14"><a href="#cb508-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb508-15"><a href="#cb508-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Law 1: map_tree Fun.id t = t *)</span></span>
+<span id="cb508-16"><a href="#cb508-16" aria-hidden="true" tabindex="-1"></a><span class="co">(* Law 2: map_tree (fun x -&gt; f (g x)) t *)</span></span>
+<span id="cb508-17"><a href="#cb508-17" aria-hidden="true" tabindex="-1"></a><span class="co">(*      = map_tree f (map_tree g t)      *)</span></span></code></pre></div>
 <h3 id="exercise-4-naturality-verification">Exercise 4: Naturality
 verification</h3>
 <p>The function <code>List.rev</code> is a natural transformation from
@@ -17167,29 +17433,29 @@ connection.</p>
 lenses <code>street_lens</code>, <code>addr_lens</code>, and compose
 them to create <code>employee_street_lens</code>. Verify all three lens
 laws (Get-Set, Set-Get, Set-Set) for the composed lens.</p>
-<div class="sourceCode" id="cb497"><pre
-class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb497-1"><a href="#cb497-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 6 *)</span></span>
-<span id="cb497-2"><a href="#cb497-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> address = { street : <span class="dt">string</span>; city : <span class="dt">string</span> }</span>
-<span id="cb497-3"><a href="#cb497-3" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> employee = { name : <span class="dt">string</span>; addr : address }</span>
-<span id="cb497-4"><a href="#cb497-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb497-5"><a href="#cb497-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> street_lens : (address, <span class="dt">string</span>) lens = {</span>
-<span id="cb497-6"><a href="#cb497-6" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> a -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
-<span id="cb497-7"><a href="#cb497-7" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> s a -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
-<span id="cb497-8"><a href="#cb497-8" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb497-9"><a href="#cb497-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb497-10"><a href="#cb497-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> addr_lens : (employee, address) lens = {</span>
-<span id="cb497-11"><a href="#cb497-11" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> e -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
-<span id="cb497-12"><a href="#cb497-12" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> a e -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
-<span id="cb497-13"><a href="#cb497-13" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb497-14"><a href="#cb497-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb497-15"><a href="#cb497-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Compose using compose_lens from Section 12.7: *)</span></span>
-<span id="cb497-16"><a href="#cb497-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> employee_street = compose_lens addr_lens street_lens</span>
-<span id="cb497-17"><a href="#cb497-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb497-18"><a href="#cb497-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Test data: *)</span></span>
-<span id="cb497-19"><a href="#cb497-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> emp = { name = <span class="st">&quot;Alice&quot;</span>;</span>
-<span id="cb497-20"><a href="#cb497-20" aria-hidden="true" tabindex="-1"></a>            addr = { street = <span class="st">&quot;123 Main&quot;</span>; city = <span class="st">&quot;NYC&quot;</span> } }</span>
-<span id="cb497-21"><a href="#cb497-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb497-22"><a href="#cb497-22" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify all three lens laws for the composed lens. *)</span></span></code></pre></div>
+<div class="sourceCode" id="cb509"><pre
+class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb509-1"><a href="#cb509-1" aria-hidden="true" tabindex="-1"></a><span class="co">(* Starter code for Exercise 6 *)</span></span>
+<span id="cb509-2"><a href="#cb509-2" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> address = { street : <span class="dt">string</span>; city : <span class="dt">string</span> }</span>
+<span id="cb509-3"><a href="#cb509-3" aria-hidden="true" tabindex="-1"></a><span class="kw">type</span> employee = { name : <span class="dt">string</span>; addr : address }</span>
+<span id="cb509-4"><a href="#cb509-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb509-5"><a href="#cb509-5" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> street_lens : (address, <span class="dt">string</span>) lens = {</span>
+<span id="cb509-6"><a href="#cb509-6" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> a -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
+<span id="cb509-7"><a href="#cb509-7" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> s a -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
+<span id="cb509-8"><a href="#cb509-8" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb509-9"><a href="#cb509-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb509-10"><a href="#cb509-10" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> addr_lens : (employee, address) lens = {</span>
+<span id="cb509-11"><a href="#cb509-11" aria-hidden="true" tabindex="-1"></a>  get = (<span class="kw">fun</span> e -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
+<span id="cb509-12"><a href="#cb509-12" aria-hidden="true" tabindex="-1"></a>  set = (<span class="kw">fun</span> a e -&gt; <span class="dt">failwith</span> <span class="st">&quot;todo&quot;</span>);</span>
+<span id="cb509-13"><a href="#cb509-13" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb509-14"><a href="#cb509-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb509-15"><a href="#cb509-15" aria-hidden="true" tabindex="-1"></a><span class="co">(* Compose using compose_lens from Section 12.7: *)</span></span>
+<span id="cb509-16"><a href="#cb509-16" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> employee_street = compose_lens addr_lens street_lens</span>
+<span id="cb509-17"><a href="#cb509-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb509-18"><a href="#cb509-18" aria-hidden="true" tabindex="-1"></a><span class="co">(* Test data: *)</span></span>
+<span id="cb509-19"><a href="#cb509-19" aria-hidden="true" tabindex="-1"></a><span class="kw">let</span> emp = { name = <span class="st">&quot;Alice&quot;</span>;</span>
+<span id="cb509-20"><a href="#cb509-20" aria-hidden="true" tabindex="-1"></a>            addr = { street = <span class="st">&quot;123 Main&quot;</span>; city = <span class="st">&quot;NYC&quot;</span> } }</span>
+<span id="cb509-21"><a href="#cb509-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb509-22"><a href="#cb509-22" aria-hidden="true" tabindex="-1"></a><span class="co">(* Verify all three lens laws for the composed lens. *)</span></span></code></pre></div>
 <h3 id="exercise-7-prism-round-trip">Exercise 7: Prism round-trip</h3>
 <p>For the type
 <code>type shape = Circle of float | Rect of float * float</code>, write

--- a/site/old_lectures_as_book.html
+++ b/site/old_lectures_as_book.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
@@ -9,7 +9,9 @@
   <meta name="author" content="GPT-5.2" />
   <title>Functional Programming 2012-2013</title>
   <style>
-    code{white-space: pre-wrap;}
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
     span.smallcaps{font-variant: small-caps;}
     div.columns{display: flex; gap: min(4vw, 1.5em);}
     div.column{flex: auto; overflow-x: auto;}
@@ -9987,10 +9989,10 @@ whether a rule applies.</p>
 grammars are a small subset of <em>context free grammars</em>, the
 semantic actions can depend on context: actions can be functions that
 take some form of context as input.</p></li>
-<li><p>Positions are available in actions via keywords <span
-class="math inline">`startpos`(`x`)
-and</span><code>endpos</code>(<code>x</code>) where <code>x</code> is
-name given to part of pattern.</p>
+<li><p>Positions are available in actions via keywords
+$<code>startpos</code>(<code>x</code>) and
+$<code>endpos</code>(<code>x</code>) where <code>x</code> is name given
+to part of pattern.</p>
 <ul>
 <li>Do not use the Parsing module from OCaml standard library.</li>
 </ul></li>


### PR DESCRIPTION
## Summary

`dune runtest` failed with a single mdx diff on `chapter10/README.md`: the
evaluated code referenced `Draw.grey`, which the installed Bogue version
(`bogue 20260208`) does not export — `Error: Unbound value Draw.grey`.

Bogue's `Draw` module (`B_draw`) exposes no bare `grey` value; named greys live
in `RGB`/`RGBA` or are reachable via `Draw.find_color`. This replaces
`Draw.opaque Draw.grey` → `Draw.opaque (Draw.find_color "grey")` (RGB
`(100,100,100)`, full alpha), keeping the `Draw.`-qualified style already in
scope via the block's `let open Bogue in`.

## Changes

- `chapter10/README.md` — both occurrences: the mdx-evaluated `env=ch10`
  `run_bogue` block (the one that errored) and the `ocaml skip` `reactimate`
  block (so the published text a reader copies out is consistent).
- `chapter10/chapter10.ml` — 3 occurrences. **Not in the proposal's
  README-only occurrence list**, but a project-wide grep + `dune build` showed
  this built executable fails identically. Absorbed in scope (flagged with a
  `scope-expansion:` trailer) since it blocks `dune build` with the same symbol.

## Verification

- `dune runtest` exits 0 with no mdx diff.
- `dune build` no longer errors on `chapter10/chapter10.ml`.
- `grep "Draw.grey"` across chapter10 source returns nothing.
- No other chapter regresses.

Note: a pre-existing, unrelated `@pdfs/new_book` LaTeX error (`No counter
'none' defined`) is not part of `dune runtest` and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)